### PR TITLE
feat: 블루 그린 배포 스크립트 작성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,7 +110,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "scripts,docker-compose.yml"
+          source: "scripts,docker-compose.yml,nginx"
           target: "/opt/hufsdev/backend/"
 
       - name: Deploy via SSH
@@ -120,6 +120,6 @@ jobs:
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            mkdir -p /opt/hufsdev/backend/scripts
+            mkdir -p /opt/hufsdev/backend/scripts /opt/hufsdev/backend/nginx/conf.d
             chmod +x /opt/hufsdev/backend/scripts/deploy.sh
             /opt/hufsdev/backend/scripts/deploy.sh ${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,69 @@
 # ****************************** #
-# EC2 DOCKER COMPOSE             #
-# Updated At: 26.02.25           #
-# Updated By: Chaehyeon Yeo      #
+# EC2 BLUE-GREEN DOCKER COMPOSE   #
+# Blue: 8080, Green: 8081         #
+# Nginx: 80 (ALB target)          #
 # ****************************** #
 
 services:
-  backend:
-    container_name: hufsdev-backend
+  backend-blue:
+    container_name: hufsdev-backend-blue
     image: ${IMAGE_REF:-873135413383.dkr.ecr.ap-northeast-2.amazonaws.com/hufsdev-backend:latest}
     user: "1000:1000"
-    restart: always
+    restart: "no"
     dns:
       - 172.31.0.2
     ports:
-      - "8080:8080"
+      - "${BLUE_PORT:-8080}:8080"
     env_file:
       - .env-prod
+    environment:
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILE:-prod}
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/actuator/health/liveness"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/actuator/health/readiness"]
+      interval: 10s
+      timeout: 5s
       retries: 3
       start_period: 90s
     volumes:
-      - ./logs:/app/logs
+      - ./logs/blue:/app/logs
     logging:
       driver: "json-file"
       options:
         max-size: "50m"
         max-file: "3"
+
+  backend-green:
+    container_name: hufsdev-backend-green
+    image: ${IMAGE_REF:-873135413383.dkr.ecr.ap-northeast-2.amazonaws.com/hufsdev-backend:latest}
+    user: "1000:1000"
+    restart: "no"
+    dns:
+      - 172.31.0.2
+    ports:
+      - "${GREEN_PORT:-8081}:8080"
+    env_file:
+      - .env-prod
+    environment:
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILE:-prod}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/actuator/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    volumes:
+      - ./logs/green:/app/logs
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
+
+  nginx:
+    container_name: hufsdev-nginx
+    image: nginx:1.25-alpine
+    restart: always
+    network_mode: host
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro

--- a/nginx/conf.d/upstream.conf
+++ b/nginx/conf.d/upstream.conf
@@ -1,0 +1,6 @@
+# deploy.sh가 활성 슬롯에 따라 이 파일을 덮어씀
+# network_mode: host 사용 → 127.0.0.1로 호스트 포트 직접 참조
+# 초기값: blue (8080)
+upstream backend {
+    server 127.0.0.1:8080;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,42 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+
+    # deploy.sh가 upstream.conf를 덮어써서 blue/green 전환
+    include /etc/nginx/conf.d/upstream.conf;
+
+    server {
+        listen 80;
+        server_name _;
+
+        client_max_body_size 10M;
+
+        location / {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        location /actuator/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+    }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,112 +2,187 @@
 set -euo pipefail
 
 # ---- 설정 변수 ----
-DEPLOY_DIR="/opt/hufsdev/backend"
-ECR_REGISTRY="873135413383.dkr.ecr.ap-northeast-2.amazonaws.com"
-REPO_NAME="hufsdev-backend"
-CONTAINER_NAME="hufsdev-backend"
-HEALTH_URL="http://localhost:8080/actuator/health/liveness"
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/hufsdev/backend}"
+ECR_REGISTRY="${ECR_REGISTRY:-873135413383.dkr.ecr.ap-northeast-2.amazonaws.com}"
+REPO_NAME="${REPO_NAME:-hufsdev-backend}"
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+
+BLUE_SERVICE="backend-blue"
+GREEN_SERVICE="backend-green"
+NGINX_SERVICE="nginx"
+BLUE_PORT="${BLUE_PORT:-8080}"
+GREEN_PORT="${GREEN_PORT:-8081}"
+
+HEALTH_PATH="/actuator/health/readiness"
+HEALTH_RETRIES=40
+HEALTH_INTERVAL=2
 CURL_OPTS=(--connect-timeout 5 --max-time 15 -fsS)
+
 LOCK_FILE="$DEPLOY_DIR/.deploy.lock"
+ACTIVE_SLOT_FILE="$DEPLOY_DIR/.active_slot"
+NGINX_UPSTREAM_CONF="$DEPLOY_DIR/nginx/conf.d/upstream.conf"
 
 cd "$DEPLOY_DIR"
 
 # ---- 실행 잠금 ----
 exec 9>"$LOCK_FILE"
-flock -n 9 || { echo "Another deployment is already running"; exit 1; }
-mkdir -p logs
+flock -n 9 || { echo "[!] Another deployment is already running"; exit 1; }
+mkdir -p logs/blue logs/green nginx/conf.d
 
 IMAGE_TAG="${1:-latest}"
 export IMAGE_REF="$ECR_REGISTRY/$REPO_NAME:$IMAGE_TAG"
-echo "Deploying image: $IMAGE_REF"
-
 echo "===== DEPLOY START: $(date -u +"%Y-%m-%dT%H:%M:%SZ") ====="
+echo "Image: $IMAGE_REF"
 
-# ECR login - IAM Role 기반
-echo "[1/8] ECR login"
-aws ecr get-login-password --region ap-northeast-2 \
-| docker login --username AWS --password-stdin "$ECR_REGISTRY"
-
-echo "[2/8] Save rollback target (current running image)"
-CURRENT_IMAGE=$(docker inspect "$CONTAINER_NAME" --format '{{.Config.Image}}' 2>/dev/null || true)
-if [[ -n "$CURRENT_IMAGE" ]]; then
-  echo "$CURRENT_IMAGE" > .prev_ref
-  echo "Rollback target: $CURRENT_IMAGE"
-else
-  rm -f .prev_ref
-  echo "No running container - skip rollback target"
-fi
-
-echo "[debug] IMAGE_REF=$IMAGE_REF"
-echo "[debug] Resolved image (ECR login 후, pull 직전):"
-docker compose config | sed -n '/image:/p'
-
-echo "[3/8] Pull image ($IMAGE_TAG)"
-docker compose pull
-
-echo "[4/8] Restart container"
-HEALTH_OK=false
-if docker compose down && docker compose up -d --remove-orphans; then
-  echo "[5/8] Health check"
-  for _ in {1..40}; do
-    if curl "${CURL_OPTS[@]}" "$HEALTH_URL" >/dev/null; then
-      HEALTH_OK=true
-      echo "Health OK"
-      break
+# -----------------------------------------------------------------------------
+# (1) 현재 활성 슬롯 감지
+# -----------------------------------------------------------------------------
+echo "[1/8] Detect active slot"
+detect_active_slot() {
+  if [[ -f "$ACTIVE_SLOT_FILE" ]]; then
+    local slot
+    slot=$(cat "$ACTIVE_SLOT_FILE")
+    if [[ "$slot" == "blue" || "$slot" == "green" ]]; then
+      echo "$slot"
+      return
     fi
-    sleep 2
-  done
-else
-  echo "[!] Restart failed before health check"
+  fi
+  if docker ps -q -f "name=hufsdev-backend-blue" --format '{{.Names}}' 2>/dev/null | grep -q .; then
+    echo "blue"
+    return
+  fi
+  if docker ps -q -f "name=hufsdev-backend-green" --format '{{.Names}}' 2>/dev/null | grep -q .; then
+    echo "green"
+    return
+  fi
+  # 레거시 마이그레이션: 기존 hufsdev-backend → blue로 간주
+  if docker ps -q -f "name=hufsdev-backend" --format '{{.Names}}' 2>/dev/null | grep -q .; then
+    echo "blue"
+    return
+  fi
+  echo ""
+}
+
+ACTIVE=$(detect_active_slot)
+FIRST_DEPLOY=false
+if [[ -z "$ACTIVE" ]]; then
+  echo "  No active slot found - first deploy"
+  ACTIVE="blue"
+  FIRST_DEPLOY=true
 fi
+echo "  Active slot: $ACTIVE"
+
+# -----------------------------------------------------------------------------
+# (2) 비활성 슬롯 결정 (배포 타겟)
+# -----------------------------------------------------------------------------
+echo "[2/8] Determine target slot"
+if [[ "$FIRST_DEPLOY" == "true" ]]; then
+  TARGET="blue"
+  TARGET_SERVICE="$BLUE_SERVICE"
+  TARGET_PORT="$BLUE_PORT"
+elif [[ "$ACTIVE" == "blue" ]]; then
+  TARGET="green"
+  TARGET_SERVICE="$GREEN_SERVICE"
+  TARGET_PORT="$GREEN_PORT"
+else
+  TARGET="blue"
+  TARGET_SERVICE="$BLUE_SERVICE"
+  TARGET_PORT="$BLUE_PORT"
+fi
+echo "  Target slot: $TARGET ($TARGET_SERVICE, port $TARGET_PORT)"
+
+# -----------------------------------------------------------------------------
+# (3) 최신 이미지 pull
+# -----------------------------------------------------------------------------
+echo "[3/8] ECR login & pull image"
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+docker compose pull "$TARGET_SERVICE"
+
+# -----------------------------------------------------------------------------
+# (4) target 슬롯 컨테이너 실행 (기존 컨테이너 유지)
+# -----------------------------------------------------------------------------
+echo "[4/8] Start target slot container ($TARGET_SERVICE)"
+docker compose up -d --force-recreate "$TARGET_SERVICE"
+echo "  Waiting for container to be ready..."
+sleep 5
+
+# -----------------------------------------------------------------------------
+# (5) 헬스체크 수행
+# -----------------------------------------------------------------------------
+echo "[5/8] Health check ($TARGET_PORT -> $HEALTH_PATH)"
+HEALTH_URL="http://127.0.0.1:$TARGET_PORT$HEALTH_PATH"
+HEALTH_OK=false
+for i in $(seq 1 "$HEALTH_RETRIES"); do
+  if curl "${CURL_OPTS[@]}" "$HEALTH_URL" >/dev/null 2>&1; then
+    HEALTH_OK=true
+    echo "  Health OK (attempt $i)"
+    break
+  fi
+  echo "  Attempt $i/$HEALTH_RETRIES - waiting ${HEALTH_INTERVAL}s..."
+  sleep "$HEALTH_INTERVAL"
+done
 
 if [[ "$HEALTH_OK" != "true" ]]; then
-  echo "[!] Health FAILED - attempting rollback"
-  echo "[!] Dump recent logs"
-  docker compose logs --no-color --tail=200 backend || true
-  if [[ -f .prev_ref ]]; then
-    ROLLBACK_REF=$(cat .prev_ref)
-    echo "Rolling back to: $ROLLBACK_REF"
-    export IMAGE_REF="$ROLLBACK_REF"
-    docker compose pull
-    ROLLBACK_HEALTH_OK=false
-    if docker compose down && docker compose up -d --remove-orphans; then
-      echo "Waiting for rollback container to be healthy..."
-      for _ in {1..20}; do
-        if curl "${CURL_OPTS[@]}" "$HEALTH_URL" >/dev/null; then
-          ROLLBACK_HEALTH_OK=true
-          break
-        fi
-        sleep 2
-      done
-    else
-      echo "[!] Rollback container failed to start"
-    fi
-    if [[ "$ROLLBACK_HEALTH_OK" == "true" ]]; then
-      echo "Rollback OK - previous version restored"
-    else
-      echo "Rollback FAILED - manual intervention required"
-    fi
-  else
-    echo "No .prev_ref - cannot rollback"
-  fi
+  echo "[!] Health check FAILED - rolling back"
+  echo "[!] Dump target container logs:"
+  docker compose logs --no-color --tail=100 "$TARGET_SERVICE" 2>/dev/null || true
+  echo "[!] Stopping and removing failed target container"
+  docker compose stop "$TARGET_SERVICE" 2>/dev/null || true
+  docker rm -f "hufsdev-backend-$TARGET" 2>/dev/null || true
+  echo "[!] Rollback complete - active slot unchanged ($ACTIVE)"
   exit 1
 fi
 
-echo "[6/8] Show status"
-docker ps --filter "name=$CONTAINER_NAME"
+# -----------------------------------------------------------------------------
+# (6) 트래픽 전환 (Nginx upstream 변경)
+# -----------------------------------------------------------------------------
+echo "[6/8] Traffic switch (Nginx upstream -> $TARGET)"
+if [[ "$TARGET" == "blue" ]]; then
+  echo 'upstream backend { server 127.0.0.1:8080; }' > "$NGINX_UPSTREAM_CONF"
+else
+  echo 'upstream backend { server 127.0.0.1:8081; }' > "$NGINX_UPSTREAM_CONF"
+fi
+if docker ps -q -f "name=hufsdev-nginx" --format '{{.Names}}' 2>/dev/null | grep -q .; then
+  docker exec hufsdev-nginx nginx -s reload 2>/dev/null || docker compose restart "$NGINX_SERVICE"
+else
+  echo "  Starting nginx..."
+  docker compose up -d "$NGINX_SERVICE"
+fi
+echo "  Traffic switched to $TARGET"
 
-echo "[7/8] Cleanup unused Docker resources"
-docker system prune -f
+# -----------------------------------------------------------------------------
+# (7) 기존 슬롯 컨테이너 종료
+# -----------------------------------------------------------------------------
+echo "[7/8] Stop previous slot container"
+echo "$TARGET" > "$ACTIVE_SLOT_FILE"
+if [[ "$FIRST_DEPLOY" != "true" ]]; then
+  if [[ "$ACTIVE" == "blue" ]]; then
+    docker compose stop "$BLUE_SERVICE" 2>/dev/null || true
+    echo "  Stopped $BLUE_SERVICE"
+  else
+    docker compose stop "$GREEN_SERVICE" 2>/dev/null || true
+    echo "  Stopped $GREEN_SERVICE"
+  fi
+  # 레거시 마이그레이션: 기존 hufsdev-backend 컨테이너 정리
+  if docker ps -a -q -f "name=hufsdev-backend" --format '{{.Names}}' 2>/dev/null | grep -q .; then
+    docker stop hufsdev-backend 2>/dev/null || true
+    docker rm hufsdev-backend 2>/dev/null || true
+    echo "  Stopped legacy hufsdev-backend (migration)"
+  fi
+else
+  echo "  First deploy - no previous container to stop"
+fi
 
-echo "[8/8] Remove old images (keep last 2)"
-docker images "$ECR_REGISTRY/$REPO_NAME" \
-  --format "{{.CreatedAt}} {{.Repository}}:{{.Tag}}" \
-  | grep -v ":latest" \
-  | sort -r \
-  | awk '{print $NF}' \
-  | tail -n +3 \
-  | xargs -r docker rmi || true
+# -----------------------------------------------------------------------------
+# (8) 정리 및 완료
+# -----------------------------------------------------------------------------
+echo "[8/8] Cleanup"
+docker system prune -f 2>/dev/null || true
+docker images "$ECR_REGISTRY/$REPO_NAME" --format "{{.CreatedAt}} {{.Repository}}:{{.Tag}}" \
+  | grep -v ":latest" | sort -r | awk '{print $NF}' | tail -n +3 \
+  | xargs -r docker rmi 2>/dev/null || true
 
 echo "===== DEPLOY COMPLETE ====="
+echo "Active slot: $TARGET"
 echo "DEPLOY_SUCCESS"


### PR DESCRIPTION
## 📌 관련 이슈
- closes #37

## ✨ 작업 내용
- 단일 EC2 환경에서 블루-그린 유사 배포(8080/8081 포트 스위칭) 적용
- `docker compose down` 없이 무중단 배포 가능하도록 구조 개선

## 🔍 주요 변경 사항
- **docker-compose.yml**: `backend-blue`(8080), `backend-green`(8081), `nginx`(80) 서비스 정의
- **deploy.sh**: 블루-그린 배포 로직으로 전면 수정
  - 활성 슬롯 감지 → 비활성 슬롯에 배포 → 헬스체크 → Nginx upstream 전환 → 기존 슬롯 종료
  - readiness 헬스체크, 롤백 처리, 레거시 마이그레이션 대응
- **nginx/**: Nginx 설정 추가 (upstream.conf로 blue/green 전환)
- **CD 워크플로우**: `nginx` 폴더 동기화 추가

## 🧪 테스트 여부
- [ ] 로컬 테스트 완료
- [ ] 테스트 코드 추가 / 수정
- [x] 테스트 없음 (이유: 배포 스크립트 및 인프라 변경으로, 실제 EC2 배포 환경에서 검증 필요)

## 🤖 리뷰 포인트
- deploy.sh 블루-그린 흐름 검토
- Nginx `network_mode: host` 사용 여부

## ⚠️ 참고 사항
- **머지 후 필수 작업**: 새 Target Group(포트 80) 생성 후 ALB Listener 전환 필요