### PR TITLE
feat: 댓글 응답에 viewer(liked, isAuthor) 추가

### DIFF
--- a/src/main/java/com/project/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/global/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/departments").permitAll()
                         // 비로그인 허용: 메인 홈 게시글 목록/상세 조회
                         .requestMatchers(HttpMethod.GET, "/api/v1/boards/*/posts").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/lectures").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/lectures/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/promotions").permitAll()

--- a/src/main/java/com/project/post/application/dto/CommentViewerResponse.java
+++ b/src/main/java/com/project/post/application/dto/CommentViewerResponse.java
@@ -1,0 +1,15 @@
+package com.project.post.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CommentViewerResponse(
+        boolean liked,
+        @JsonProperty("isAuthor")
+        boolean author
+) {
+    private static final CommentViewerResponse GUEST = new CommentViewerResponse(false, false);
+
+    public static CommentViewerResponse guest() {
+        return GUEST;
+    }
+}

--- a/src/main/java/com/project/post/application/dto/PostCommentResponse.java
+++ b/src/main/java/com/project/post/application/dto/PostCommentResponse.java
@@ -14,6 +14,7 @@ public record PostCommentResponse(
         boolean isDeleted,
         long likeCount,
         Instant createdAt,
+        CommentViewerResponse viewer,
         List<PostCommentResponse> replies,
         boolean hasMoreReplies
 ) {

--- a/src/main/java/com/project/post/application/service/CommentViewerStateService.java
+++ b/src/main/java/com/project/post/application/service/CommentViewerStateService.java
@@ -1,0 +1,15 @@
+package com.project.post.application.service;
+
+import com.project.post.application.dto.CommentViewerResponse;
+import org.springframework.lang.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface CommentViewerStateService {
+
+    Map<Long, CommentViewerResponse> resolveForComments(
+            @Nullable Long viewerUserId,
+            Collection<Long> commentIds,
+            @Nullable Map<Long, Long> authorUserIdByCommentId);
+}

--- a/src/main/java/com/project/post/application/service/PostCommentQueryService.java
+++ b/src/main/java/com/project/post/application/service/PostCommentQueryService.java
@@ -1,10 +1,15 @@
 package com.project.post.application.service;
 
 import com.project.post.application.dto.PostCommentResponse;
-import org.springframework.lang.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
 public interface PostCommentQueryService {
 
-    Page<PostCommentResponse> getComments(@NonNull Long postId, @NonNull Pageable pageable);
+    Page<PostCommentResponse> getComments(
+            @NonNull Long postId,
+            @NonNull Pageable pageable,
+            @Nullable Long viewerUserId);
 }

--- a/src/main/java/com/project/post/application/service/impl/CommentViewerStateServiceImpl.java
+++ b/src/main/java/com/project/post/application/service/impl/CommentViewerStateServiceImpl.java
@@ -1,0 +1,65 @@
+package com.project.post.application.service.impl;
+
+import com.project.post.application.dto.CommentViewerResponse;
+import com.project.post.application.service.CommentViewerStateService;
+import com.project.post.domain.repository.PostCommentLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentViewerStateServiceImpl implements CommentViewerStateService {
+
+    private final PostCommentLikeRepository postCommentLikeRepository;
+
+    @Override
+    public Map<Long, CommentViewerResponse> resolveForComments(
+            @Nullable Long viewerUserId,
+            Collection<Long> commentIds,
+            @Nullable Map<Long, Long> authorUserIdByCommentId) {
+        Objects.requireNonNull(commentIds, "commentIds");
+        LinkedHashSet<Long> idSet = new LinkedHashSet<>(commentIds);
+        if (idSet.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Long> authorMap = authorUserIdByCommentId == null
+                ? Collections.emptyMap()
+                : authorUserIdByCommentId;
+        if (viewerUserId == null) {
+            CommentViewerResponse guest = CommentViewerResponse.guest();
+            return idSet.stream().collect(Collectors.toMap(id -> id, id -> guest));
+        }
+        Set<Long> likedIds = new HashSet<>(
+                postCommentLikeRepository.findCommentIdsLikedByUserAndCommentIdIn(idSet, viewerUserId));
+        return idSet.stream()
+                .collect(Collectors.toMap(
+                        id -> id,
+                        id -> viewerResponseForLoggedIn(viewerUserId, id, likedIds, authorMap)));
+    }
+
+    private static CommentViewerResponse viewerResponseForLoggedIn(
+            Long viewerUserId,
+            Long commentId,
+            Set<Long> likedIds,
+            Map<Long, Long> authorUserIdByCommentId) {
+        return new CommentViewerResponse(
+                likedIds.contains(commentId),
+                isViewerAuthor(viewerUserId, authorUserIdByCommentId.get(commentId)));
+    }
+
+    private static boolean isViewerAuthor(Long viewerUserId, Long authorUserId) {
+        return authorUserId != null && authorUserId.equals(viewerUserId);
+    }
+}

--- a/src/main/java/com/project/post/application/service/impl/PostCommentQueryServiceImpl.java
+++ b/src/main/java/com/project/post/application/service/impl/PostCommentQueryServiceImpl.java
@@ -2,22 +2,26 @@ package com.project.post.application.service.impl;
 
 import com.project.global.error.BusinessException;
 import com.project.global.error.ErrorCode;
+import com.project.post.application.dto.CommentViewerResponse;
 import com.project.post.application.dto.PostCommentResponse;
+import com.project.post.application.service.CommentViewerStateService;
 import com.project.post.application.service.PostCommentQueryService;
 import com.project.post.domain.constants.PostConstants;
 import com.project.post.domain.entity.PostComment;
 import com.project.post.domain.repository.PostCommentRepository;
 import com.project.post.domain.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.lang.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -34,9 +38,13 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
 
     private final PostRepository postRepository;
     private final PostCommentRepository commentRepository;
+    private final CommentViewerStateService commentViewerStateService;
 
     @Override
-    public Page<PostCommentResponse> getComments(@NonNull Long postId, @NonNull Pageable pageable) {
+    public Page<PostCommentResponse> getComments(
+            @NonNull Long postId,
+            @NonNull Pageable pageable,
+            @Nullable Long viewerUserId) {
         if (!postRepository.existsActiveById(postId)) {
             throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "게시글을 찾을 수 없습니다.");
         }
@@ -48,14 +56,56 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
         Page<PostComment> rootComments = commentRepository.findRootComments(postId, safePageable);
         Map<Long, List<PostComment>> repliesByParentId = loadRepliesByParentId(rootComments);
 
+        List<PostComment> rootsOnPage = rootComments.getContent();
+        Map<Long, Long> authorByCommentId = buildAuthorByCommentIdForPage(rootsOnPage, repliesByParentId);
+        LinkedHashSet<Long> commentIdsOnPage = collectCommentIdsForPage(rootsOnPage, repliesByParentId);
+        Map<Long, CommentViewerResponse> viewerByCommentId = commentViewerStateService.resolveForComments(
+                viewerUserId, commentIdsOnPage, authorByCommentId);
+
         return rootComments.map(root -> {
             List<PostComment> replies = repliesByParentId.getOrDefault(root.getId(), List.of());
             boolean hasMoreReplies = replies.size() > MAX_REPLIES_PER_ROOT;
             List<PostComment> replyList = hasMoreReplies
                     ? replies.subList(0, MAX_REPLIES_PER_ROOT)
                     : replies;
-            return toResponseWithReplies(root, replyList, hasMoreReplies);
+            return toResponseWithReplies(root, replyList, hasMoreReplies, viewerByCommentId);
         });
+    }
+
+    private static LinkedHashSet<Long> collectCommentIdsForPage(
+            List<PostComment> roots, Map<Long, List<PostComment>> repliesByParentId) {
+        LinkedHashSet<Long> ids = new LinkedHashSet<>();
+        for (PostComment root : roots) {
+            ids.add(root.getId());
+            List<PostComment> replies = repliesByParentId.getOrDefault(root.getId(), List.of());
+            int n = Math.min(replies.size(), MAX_REPLIES_PER_ROOT);
+            for (int i = 0; i < n; i++) {
+                ids.add(replies.get(i).getId());
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * 삭제된 댓글은 작성자 ID를 넣지 않아 viewer.isAuthor 가 항상 false
+     */
+    private static Map<Long, Long> buildAuthorByCommentIdForPage(
+            List<PostComment> roots, Map<Long, List<PostComment>> repliesByParentId) {
+        Map<Long, Long> map = new HashMap<>();
+        for (PostComment root : roots) {
+            if (!root.isDeleted()) {
+                map.put(root.getId(), root.getUser().getId());
+            }
+            List<PostComment> replies = repliesByParentId.getOrDefault(root.getId(), List.of());
+            int n = Math.min(replies.size(), MAX_REPLIES_PER_ROOT);
+            for (int i = 0; i < n; i++) {
+                PostComment reply = replies.get(i);
+                if (!reply.isDeleted()) {
+                    map.put(reply.getId(), reply.getUser().getId());
+                }
+            }
+        }
+        return map;
     }
 
     private Map<Long, List<PostComment>> loadRepliesByParentId(Page<PostComment> rootComments) {
@@ -79,7 +129,10 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
     }
 
     /** 삭제 댓글: deleted=true, content·작성자 null */
-    private PostCommentResponse toResponse(PostComment comment, Long parentId) {
+    private PostCommentResponse toResponse(
+            PostComment comment,
+            Long parentId,
+            Map<Long, CommentViewerResponse> viewerByCommentId) {
         boolean deleted = comment.isDeleted();
         return new PostCommentResponse(
                 comment.getId(),
@@ -92,14 +145,19 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
                 deleted,
                 comment.getLikeCount(),
                 comment.getCreatedAt(),
+                viewerByCommentId.getOrDefault(comment.getId(), CommentViewerResponse.guest()),
                 List.of(),
                 false
         );
     }
 
-    private PostCommentResponse toResponseWithReplies(PostComment root, List<PostComment> replies, boolean hasMoreReplies) {
+    private PostCommentResponse toResponseWithReplies(
+            PostComment root,
+            List<PostComment> replies,
+            boolean hasMoreReplies,
+            Map<Long, CommentViewerResponse> viewerByCommentId) {
         List<PostCommentResponse> replyList = replies.stream()
-                .map(reply -> toResponse(reply, root.getId()))
+                .map(reply -> toResponse(reply, root.getId(), viewerByCommentId))
                 .collect(Collectors.toList());
 
         boolean deleted = root.isDeleted();
@@ -114,6 +172,7 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
                 deleted,
                 root.getLikeCount(),
                 root.getCreatedAt(),
+                viewerByCommentId.getOrDefault(root.getId(), CommentViewerResponse.guest()),
                 replyList,
                 hasMoreReplies
         );

--- a/src/main/java/com/project/post/domain/repository/PostCommentLikeRepository.java
+++ b/src/main/java/com/project/post/domain/repository/PostCommentLikeRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostCommentLikeRepository extends JpaRepository<PostCommentLike, Long> {
@@ -20,6 +22,11 @@ public interface PostCommentLikeRepository extends JpaRepository<PostCommentLike
 
     @Query("SELECT (COUNT(pcl) > 0) FROM PostCommentLike pcl WHERE pcl.comment.id = :commentId AND pcl.user.id = :userId")
     boolean existsByCommentIdAndUserId(@Param("commentId") Long commentId, @Param("userId") Long userId);
+
+    @Query("SELECT pcl.comment.id FROM PostCommentLike pcl WHERE pcl.comment.id IN :commentIds AND pcl.user.id = :userId")
+    List<Long> findCommentIdsLikedByUserAndCommentIdIn(
+            @Param("commentIds") Collection<Long> commentIds,
+            @Param("userId") Long userId);
 
     @Modifying
     @Query(value = "INSERT INTO post_comment_likes (comment_id, user_id, created_at) " +

--- a/src/main/java/com/project/post/presentation/controller/PostCommentController.java
+++ b/src/main/java/com/project/post/presentation/controller/PostCommentController.java
@@ -6,7 +6,9 @@ import com.project.post.application.dto.PostCommentCreateResponse;
 import com.project.post.application.dto.PostCommentRequest;
 import com.project.post.application.dto.PostCommentResponse;
 import com.project.global.annotation.CurrentUser;
+import com.project.global.annotation.OptionalSessionUser;
 import com.project.post.application.service.PostCommentCommandService;
+import com.project.post.presentation.support.ViewerUserId;
 import com.project.post.application.service.PostCommentLikeService;
 import com.project.post.application.service.PostCommentQueryService;
 import com.project.user.domain.entity.User;
@@ -33,6 +35,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/v1")
 @Validated
@@ -57,8 +61,10 @@ public class PostCommentController implements PostCommentControllerDocs {
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<CommonResponse<PageResponse<PostCommentResponse>>> getComments(
             @PathVariable @Positive @NonNull Long postId,
-            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) @NonNull Pageable pageable) {
-        Page<PostCommentResponse> comments = postCommentQueryService.getComments(postId, pageable);
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) @NonNull Pageable pageable,
+            @OptionalSessionUser Optional<User> optionalViewer) {
+        Page<PostCommentResponse> comments = postCommentQueryService.getComments(
+                postId, pageable, ViewerUserId.from(optionalViewer));
         return ResponseEntity.ok(CommonResponse.ok(PageResponse.of(comments)));
     }
 

--- a/src/main/java/com/project/post/presentation/swagger/PostCommentControllerDocs.java
+++ b/src/main/java/com/project/post/presentation/swagger/PostCommentControllerDocs.java
@@ -1,5 +1,6 @@
 package com.project.post.presentation.swagger;
 
+import com.project.global.annotation.OptionalSessionUser;
 import com.project.global.response.CommonResponse;
 import com.project.global.response.PageResponse;
 import com.project.post.application.dto.LikeScrapToggleResponse;
@@ -18,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 
+import java.util.Optional;
+
 @Tag(name = "PostComment", description = "게시글 댓글 API")
 public interface PostCommentControllerDocs {
 
@@ -29,11 +32,12 @@ public interface PostCommentControllerDocs {
             @RequestBody(description = "댓글 작성 요청") @Valid @NonNull PostCommentRequest request,
             @Parameter(hidden = true) @NonNull User user);
 
-    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 페이징하여 조회합니다. 각 루트 댓글의 답글은 최대 20개까지 반환되며, 초과 시 hasMoreReplies=true로 표시됩니다.")
+    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 페이징하여 조회합니다. 각 루트 댓글의 답글은 최대 20개까지 반환되며, 초과 시 hasMoreReplies=true로 표시됩니다. 로그인 시 viewer.liked / viewer.isAuthor 에 현재 사용자 기준 상태가 포함됩니다.")
     @ApiResponse(responseCode = "200", description = "성공")
     ResponseEntity<CommonResponse<PageResponse<PostCommentResponse>>> getComments(
             @Parameter(description = "게시글 ID") @Positive @NonNull Long postId,
-            @NonNull Pageable pageable);
+            @NonNull Pageable pageable,
+            @Parameter(hidden = true) @OptionalSessionUser Optional<User> optionalViewer);
 
     @Operation(summary = "댓글 삭제", description = "댓글을 소프트 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "성공")

--- a/src/test/java/com/project/post/application/dto/CommentViewerResponseJsonTest.java
+++ b/src/test/java/com/project/post/application/dto/CommentViewerResponseJsonTest.java
@@ -1,0 +1,22 @@
+package com.project.post.application.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentViewerResponseJsonTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("JSON 필드명은 liked, isAuthor 이다 (스크랩 없음)")
+    void serializesViewerFieldsForFrontendContract() throws Exception {
+        String json = objectMapper.writeValueAsString(new CommentViewerResponse(true, true));
+
+        assertThat(json).contains("\"liked\":true");
+        assertThat(json).contains("\"isAuthor\":true");
+        assertThat(json).doesNotContain("scrapped");
+    }
+}

--- a/src/test/java/com/project/post/application/service/CommentViewerStateServiceImplTest.java
+++ b/src/test/java/com/project/post/application/service/CommentViewerStateServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.project.post.application.service;
+
+import com.project.post.application.dto.CommentViewerResponse;
+import com.project.post.application.service.impl.CommentViewerStateServiceImpl;
+import com.project.post.domain.repository.PostCommentLikeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommentViewerStateServiceImplTest {
+
+    @Mock
+    private PostCommentLikeRepository postCommentLikeRepository;
+
+    @InjectMocks
+    private CommentViewerStateServiceImpl commentViewerStateService;
+
+    @Test
+    @DisplayName("비로그인이면 DB 조회 없이 모두 guest 뷰어 상태")
+    void guestWithoutDb() {
+        Map<Long, CommentViewerResponse> map = commentViewerStateService.resolveForComments(
+                null, List.of(1L, 2L), Map.of(1L, 99L, 2L, 10L));
+
+        assertThat(map.get(1L)).isEqualTo(CommentViewerResponse.guest());
+        assertThat(map.get(2L)).isEqualTo(CommentViewerResponse.guest());
+        verifyNoInteractions(postCommentLikeRepository);
+    }
+
+    @Test
+    @DisplayName("로그인 시 좋아요 ID를 배치 조회해 매핑한다")
+    void mapsLiked() {
+        when(postCommentLikeRepository.findCommentIdsLikedByUserAndCommentIdIn(
+                argThat(s -> s != null && s.size() == 2 && s.contains(1L) && s.contains(2L)),
+                eq(99L)))
+                .thenReturn(List.of(1L));
+
+        Map<Long, CommentViewerResponse> map = commentViewerStateService.resolveForComments(
+                99L, List.of(1L, 2L), Map.of(1L, 10L, 2L, 20L));
+
+        assertThat(map.get(1L)).isEqualTo(new CommentViewerResponse(true, false));
+        assertThat(map.get(2L)).isEqualTo(new CommentViewerResponse(false, false));
+    }
+
+    @Test
+    @DisplayName("viewerUserId가 작성자 ID와 같으면 isAuthor(author)=true")
+    void mapsAuthor() {
+        when(postCommentLikeRepository.findCommentIdsLikedByUserAndCommentIdIn(
+                argThat((Set<Long> s) -> s != null && s.size() == 2 && s.contains(1L) && s.contains(2L)),
+                eq(99L)))
+                .thenReturn(List.of());
+
+        Map<Long, CommentViewerResponse> map = commentViewerStateService.resolveForComments(
+                99L, List.of(1L, 2L), Map.of(1L, 99L, 2L, 10L));
+
+        assertThat(map.get(1L).author()).isTrue();
+        assertThat(map.get(2L).author()).isFalse();
+    }
+}

--- a/src/test/java/com/project/post/application/service/PostCommentQueryServiceTest.java
+++ b/src/test/java/com/project/post/application/service/PostCommentQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.project.post.application.service;
 
 import com.project.global.error.BusinessException;
 import com.project.global.error.ErrorCode;
+import com.project.post.application.dto.CommentViewerResponse;
 import com.project.post.application.dto.PostCommentResponse;
 import com.project.post.domain.entity.Board;
 import com.project.post.domain.entity.Post;
@@ -10,9 +11,11 @@ import com.project.post.application.service.impl.PostCommentQueryServiceImpl;
 import com.project.post.domain.repository.PostCommentRepository;
 import com.project.post.domain.repository.PostRepository;
 import com.project.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,11 +24,17 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,15 +46,29 @@ class PostCommentQueryServiceTest {
     @Mock
     private PostCommentRepository commentRepository;
 
+    @Mock
+    private CommentViewerStateService commentViewerStateService;
+
     @InjectMocks
     private PostCommentQueryServiceImpl postCommentQueryService;
+
+    @BeforeEach
+    void stubCommentViewerGuest() {
+        lenient().when(commentViewerStateService.resolveForComments(any(), any(), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Collection<Long> ids = (Collection<Long>) invocation.getArgument(1);
+                    CommentViewerResponse guest = CommentViewerResponse.guest();
+                    return ids.stream().collect(Collectors.toMap(id -> id, id -> guest));
+                });
+    }
 
     @Test
     @DisplayName("게시글이 없으면 댓글 조회는 예외를 던진다")
     void getCommentsThrowsWhenPostMissing() {
         when(postRepository.existsActiveById(1L)).thenReturn(false);
 
-        assertThatThrownBy(() -> postCommentQueryService.getComments(1L, PageRequest.of(0, 10)))
+        assertThatThrownBy(() -> postCommentQueryService.getComments(1L, PageRequest.of(0, 10), null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
@@ -69,7 +92,7 @@ class PostCommentQueryServiceTest {
         when(commentRepository.findRepliesByParentIds(any()))
                 .thenReturn(List.of(reply));
 
-        Page<PostCommentResponse> result = postCommentQueryService.getComments(1L, PageRequest.of(0, 10));
+        Page<PostCommentResponse> result = postCommentQueryService.getComments(1L, PageRequest.of(0, 10), null);
 
         PostCommentResponse rootResponse = result.getContent().get(0);
         assertThat(rootResponse.parentCommentId()).isNull();
@@ -78,6 +101,8 @@ class PostCommentQueryServiceTest {
         assertThat(rootResponse.replies().get(0).content()).isEqualTo("reply");
         assertThat(rootResponse.isDeleted()).isFalse();
         assertThat(rootResponse.hasMoreReplies()).isFalse();
+        assertThat(rootResponse.viewer()).isEqualTo(CommentViewerResponse.guest());
+        assertThat(rootResponse.replies().get(0).viewer()).isEqualTo(CommentViewerResponse.guest());
     }
 
     @Test
@@ -96,7 +121,7 @@ class PostCommentQueryServiceTest {
         when(commentRepository.findRepliesByParentIds(any()))
                 .thenReturn(List.of());
 
-        Page<PostCommentResponse> result = postCommentQueryService.getComments(1L, PageRequest.of(0, 10));
+        Page<PostCommentResponse> result = postCommentQueryService.getComments(1L, PageRequest.of(0, 10), null);
 
         PostCommentResponse rootResponse = result.getContent().get(0);
         assertThat(rootResponse.isDeleted()).isTrue();
@@ -104,6 +129,11 @@ class PostCommentQueryServiceTest {
         assertThat(rootResponse.userId()).isNull();
         assertThat(rootResponse.userNickname()).isNull();
         assertThat(rootResponse.hasMoreReplies()).isFalse();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<Long, Long>> authorMapCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(commentViewerStateService).resolveForComments(isNull(), any(), authorMapCaptor.capture());
+        assertThat(authorMapCaptor.getValue()).doesNotContainKey(10L);
     }
 
     private static User buildUser(Long id, String nickname) {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #52 

## ✨ 작업 내용
게시글 댓글 목록 API 응답에 **현재 사용자 기준 viewer(좋아요 여부, 작성자 여부)**를 추가하고, 비로그인 사용자도 댓글 목록을 조회할 수 있도록 보안 설정을 조정했습니다. 삭제된 댓글은 작성자에게도 “내 댓글”로 판별되지 않도록 isAuthor를 내리지 않습니다.

## 🔍 주요 변경 사항

- PostCommentResponse에 viewer: CommentViewerResponse (liked, isAuthor, 스크랩 필드 없음) 추가
- CommentViewerStateService / CommentViewerStateServiceImpl 도입, PostCommentLikeRepository에 댓글 ID 배치 조회 쿼리 추가
- GET /api/v1/posts/{postId}/comments에 OptionalSessionUser 연동 및 Swagger 설명 보강
- SecurityConfig: GET /api/v1/posts/*/comments permitAll (세션 없이도 조회 가능, viewer는 guest)
- 삭제된 댓글은 작성자 맵에 포함하지 않아 viewer.isAuthor가 항상 false가 되도록 처리
- CommentViewerStateServiceImpl에 @Transactional(readOnly = true) 적용 (PostViewerStateServiceImpl과 정렬)
- 단위 테스트: CommentViewerStateServiceImplTest, PostCommentQueryServiceTest 보강(삭제 댓글 작성자 맵 검증 등), CommentViewerResponseJsonTest

## 🧪 테스트 여부
- [x] 로컬 테스트 완료
- [x] 테스트 코드 추가 / 수정
- [ ] 테스트 없음 (이유: )

## 🤖 리뷰 포인트
- 확인이 필요한 부분이 있다면 작성

## ⚠️ 참고 사항
- 리뷰어가 알면 좋은 맥락이나 주의사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  - 미인증 사용자도 게시글의 댓글을 볼 수 있도록 공개 접근 허용
  - 로그인 사용자에게 댓글에 대한 개인화된 정보 표시 (좋아요 여부, 작성자 여부)

* **테스트**
  - 새로운 뷰어 상태 검증 및 댓글 응답 매핑 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->