### PR TITLE
feat: 작성자 탈퇴 여부(isWithdrawn) API 반영 및 조회 매핑·빌드 정리

### DIFF
--- a/src/main/java/com/project/post/application/dto/PostAuthorResponse.java
+++ b/src/main/java/com/project/post/application/dto/PostAuthorResponse.java
@@ -6,7 +6,8 @@ public record PostAuthorResponse(
         String profileImageUrl,
         String departmentName,
         String representativeTrackName,
-        String tierBadgeImageUrl
+        String tierBadgeImageUrl,
+        boolean isWithdrawn
 ) {
 
     public static PostAuthorResponse fromParts(
@@ -15,14 +16,16 @@ public record PostAuthorResponse(
             String profileImageUrl,
             String departmentName,
             String representativeTrackName,
-            String tierBadgeImageUrl) {
+            String tierBadgeImageUrl,
+            boolean isWithdrawn) {
         return new PostAuthorResponse(
                 authorId,
                 nickname,
                 profileImageUrl,
                 departmentName,
                 representativeTrackName,
-                tierBadgeImageUrl
+                tierBadgeImageUrl,
+                isWithdrawn
         );
     }
 }

--- a/src/main/java/com/project/post/application/dto/PostCommentResponse.java
+++ b/src/main/java/com/project/post/application/dto/PostCommentResponse.java
@@ -8,6 +8,7 @@ public record PostCommentResponse(
         Long postId,
         Long userId,
         String userNickname,
+        boolean isWithdrawn,
         Long parentCommentId,
         int depth,
         String content,

--- a/src/main/java/com/project/post/application/mapper/PostAuthorMapper.java
+++ b/src/main/java/com/project/post/application/mapper/PostAuthorMapper.java
@@ -1,0 +1,69 @@
+package com.project.post.application.mapper;
+
+import com.project.post.application.dto.PostAuthorResponse;
+import com.project.post.domain.repository.dto.LecturePostDetailQueryResult;
+import com.project.post.domain.repository.dto.LecturePostListQueryResult;
+import com.project.post.domain.repository.dto.PostDetailQueryResult;
+import com.project.post.domain.repository.dto.PostListQueryResult;
+import com.project.post.domain.repository.dto.PromotionPostListQueryResult;
+
+public final class PostAuthorMapper {
+
+    private PostAuthorMapper() {
+    }
+
+    public static PostAuthorResponse from(PostListQueryResult row) {
+        return PostAuthorResponse.fromParts(
+                row.authorId(),
+                row.authorNickname(),
+                row.authorProfileImgUrl(),
+                row.authorDepartmentName(),
+                row.authorRepresentativeTrackName(),
+                row.authorTierBadgeImageUrl(),
+                row.authorWithdrawn());
+    }
+
+    public static PostAuthorResponse from(PostDetailQueryResult row) {
+        return PostAuthorResponse.fromParts(
+                row.authorId(),
+                row.authorNickname(),
+                row.authorProfileImgUrl(),
+                row.authorDepartmentName(),
+                row.authorRepresentativeTrackName(),
+                row.authorTierBadgeImageUrl(),
+                row.authorWithdrawn());
+    }
+
+    public static PostAuthorResponse from(LecturePostListQueryResult row) {
+        return PostAuthorResponse.fromParts(
+                row.authorId(),
+                row.authorNickname(),
+                row.authorProfileImgUrl(),
+                row.authorDepartmentName(),
+                row.authorRepresentativeTrackName(),
+                row.authorTierBadgeImageUrl(),
+                row.authorWithdrawn());
+    }
+
+    public static PostAuthorResponse from(LecturePostDetailQueryResult row) {
+        return PostAuthorResponse.fromParts(
+                row.authorId(),
+                row.authorNickname(),
+                row.authorProfileImgUrl(),
+                row.authorDepartmentName(),
+                row.authorRepresentativeTrackName(),
+                row.authorTierBadgeImageUrl(),
+                row.authorWithdrawn());
+    }
+
+    public static PostAuthorResponse from(PromotionPostListQueryResult row) {
+        return PostAuthorResponse.fromParts(
+                row.authorId(),
+                row.authorNickname(),
+                row.authorProfileImgUrl(),
+                row.authorDepartmentName(),
+                row.authorRepresentativeTrackName(),
+                row.authorTierBadgeImageUrl(),
+                row.authorWithdrawn());
+    }
+}

--- a/src/main/java/com/project/post/application/service/impl/LecturePost/LecturePostQueryServiceImpl.java
+++ b/src/main/java/com/project/post/application/service/impl/LecturePost/LecturePostQueryServiceImpl.java
@@ -2,7 +2,7 @@ package com.project.post.application.service.impl.LecturePost;
 
 import com.project.global.error.BusinessException;
 import com.project.global.error.ErrorCode;
-import com.project.post.application.dto.PostAuthorResponse;
+import com.project.post.application.mapper.PostAuthorMapper;
 import com.project.post.application.dto.PostDetailResponse;
 import com.project.post.application.dto.PostViewerResponse;
 import com.project.post.application.dto.LecturePost.LecturePostDetailResponse;
@@ -91,13 +91,7 @@ public class LecturePostQueryServiceImpl implements LecturePostQueryService {
                 result.postId(),
                 result.title(),
                 result.thumbnailUrl(),
-                PostAuthorResponse.fromParts(
-                        result.authorId(),
-                        result.authorNickname(),
-                        result.authorProfileImgUrl(),
-                        result.authorDepartmentName(),
-                        result.authorRepresentativeTrackName(),
-                        result.authorTierBadgeImageUrl()),
+                PostAuthorMapper.from(result),
                 result.department(),
                 result.campus(),
                 result.viewCount(),
@@ -137,13 +131,7 @@ public class LecturePostQueryServiceImpl implements LecturePostQueryService {
                 result.title(),
                 result.content(),
                 result.thumbnailUrl(),
-                PostAuthorResponse.fromParts(
-                        result.authorId(),
-                        result.authorNickname(),
-                        result.authorProfileImgUrl(),
-                        result.authorDepartmentName(),
-                        result.authorRepresentativeTrackName(),
-                        result.authorTierBadgeImageUrl()),
+                PostAuthorMapper.from(result),
                 result.department(),
                 result.campus(),
                 result.viewCount(),

--- a/src/main/java/com/project/post/application/service/impl/PostCommentQueryServiceImpl.java
+++ b/src/main/java/com/project/post/application/service/impl/PostCommentQueryServiceImpl.java
@@ -240,11 +240,13 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
             Long parentId,
             Map<Long, CommentViewerResponse> viewerByCommentId) {
         boolean deleted = comment.isDeleted();
+        boolean isWithdrawn = authorWithdrawnForDisplay(deleted, comment);
         return new PostCommentResponse(
                 comment.getId(),
                 comment.getPost().getId(),
                 deleted ? null : comment.getUser().getId(),
                 deleted ? null : comment.getUser().getNickname(),
+                isWithdrawn,
                 parentId,
                 comment.getDepth(),
                 deleted ? null : comment.getContent(),
@@ -267,11 +269,13 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
                 .collect(Collectors.toList());
 
         boolean deleted = root.isDeleted();
+        boolean isWithdrawn = authorWithdrawnForDisplay(deleted, root);
         return new PostCommentResponse(
                 root.getId(),
                 root.getPost().getId(),
                 deleted ? null : root.getUser().getId(),
                 deleted ? null : root.getUser().getNickname(),
+                isWithdrawn,
                 null,
                 root.getDepth(),
                 deleted ? null : root.getContent(),
@@ -282,5 +286,15 @@ public class PostCommentQueryServiceImpl implements PostCommentQueryService {
                 replyList,
                 hasMoreReplies
         );
+    }
+
+    /**
+     * 댓글 자체가 삭제된 경우에는 작성자를 노출하지 않으므로 탈퇴 여부도 내지 않는다.
+     */
+    private static boolean authorWithdrawnForDisplay(boolean commentDeleted, PostComment comment) {
+        if (commentDeleted) {
+            return false;
+        }
+        return comment.getUser().isDeleted();
     }
 }

--- a/src/main/java/com/project/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/com/project/post/application/service/impl/PostQueryServiceImpl.java
@@ -2,7 +2,7 @@ package com.project.post.application.service.impl;
 
 import com.project.global.error.BusinessException;
 import com.project.global.error.ErrorCode;
-import com.project.post.application.dto.PostAuthorResponse;
+import com.project.post.application.mapper.PostAuthorMapper;
 import com.project.post.application.dto.PostDetailResponse;
 import com.project.post.application.dto.PostListResponse;
 import com.project.post.application.dto.PostViewerResponse;
@@ -83,13 +83,7 @@ public class PostQueryServiceImpl implements PostQueryService {
                 result.postId(),
                 result.title(),
                 result.thumbnailUrl(),
-                PostAuthorResponse.fromParts(
-                        result.authorId(),
-                        result.authorNickname(),
-                        result.authorProfileImgUrl(),
-                        result.authorDepartmentName(),
-                        result.authorRepresentativeTrackName(),
-                        result.authorTierBadgeImageUrl()),
+                PostAuthorMapper.from(result),
                 result.viewCount(),
                 result.likeCount(),
                 result.scrapCount(),
@@ -137,13 +131,7 @@ public class PostQueryServiceImpl implements PostQueryService {
                 result.title(),
                 result.content(),
                 result.thumbnailUrl(),
-                PostAuthorResponse.fromParts(
-                        result.authorId(),
-                        result.authorNickname(),
-                        result.authorProfileImgUrl(),
-                        result.authorDepartmentName(),
-                        result.authorRepresentativeTrackName(),
-                        result.authorTierBadgeImageUrl()),
+                PostAuthorMapper.from(result),
                 result.viewCount(),
                 result.likeCount(),
                 result.scrapCount(),

--- a/src/main/java/com/project/post/application/service/impl/PromotionPost/PromotionPostQueryServiceImpl.java
+++ b/src/main/java/com/project/post/application/service/impl/PromotionPost/PromotionPostQueryServiceImpl.java
@@ -2,7 +2,7 @@ package com.project.post.application.service.impl.PromotionPost;
 
 import com.project.global.error.BusinessException;
 import com.project.global.error.ErrorCode;
-import com.project.post.application.dto.PostAuthorResponse;
+import com.project.post.application.mapper.PostAuthorMapper;
 import com.project.post.application.dto.PostDetailResponse;
 import com.project.post.application.dto.PostListResponse;
 import com.project.post.application.dto.PostViewerResponse;
@@ -91,13 +91,7 @@ public class PromotionPostQueryServiceImpl implements PromotionPostQueryService 
                 result.postId(),
                 result.title(),
                 result.thumbnailUrl(),
-                PostAuthorResponse.fromParts(
-                        result.authorId(),
-                        result.authorNickname(),
-                        result.authorProfileImgUrl(),
-                        result.authorDepartmentName(),
-                        result.authorRepresentativeTrackName(),
-                        result.authorTierBadgeImageUrl()),
+                PostAuthorMapper.from(result),
                 result.viewCount(),
                 result.likeCount(),
                 result.scrapCount(),

--- a/src/main/java/com/project/post/domain/entity/PostComment.java
+++ b/src/main/java/com/project/post/domain/entity/PostComment.java
@@ -18,8 +18,8 @@ import lombok.experimental.SuperBuilder;
 import java.util.Objects;
 
 /**
- * 댓글. 게시글과 달리 @SQLRestriction 없음.
- * 삭제 시 content null로 마스킹해서 목록에는 남지만 원문은 안 보임.
+ * 댓글 엔티티. {@link Post} 처럼 글로벌 필터(@SQLRestriction)를 두지 않아 삭제된 행도 조회 쿼리에서 다룰 수 있다.
+ * 삭제 시 content 를 비워 목록에는 남지만 원문은 노출하지 않는다.
  */
 @Entity
 @Table(name = "post_comments")

--- a/src/main/java/com/project/post/domain/repository/PostCommentRepositoryCustom.java
+++ b/src/main/java/com/project/post/domain/repository/PostCommentRepositoryCustom.java
@@ -9,8 +9,8 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * 댓글은 게시글과 달리 @SQLRestriction을 쓰지 않는다.
- * 삭제 댓글도 목록에 포함하고, 서비스에서 deleted/content 마스킹 처리.
+ * 댓글 커스텀 조회.
+ * 삭제된 댓글도 함께 조회할 수 있으며, 응답 마스킹은 애플리케이션 계층에서 처리한다.
  */
 public interface PostCommentRepositoryCustom {
 

--- a/src/main/java/com/project/post/domain/repository/dto/LecturePostDetailQueryResult.java
+++ b/src/main/java/com/project/post/domain/repository/dto/LecturePostDetailQueryResult.java
@@ -16,6 +16,7 @@ public record LecturePostDetailQueryResult(
         String authorDepartmentName,
         String authorRepresentativeTrackName,
         String authorTierBadgeImageUrl,
+        boolean authorWithdrawn,
         String department,
         Campus campus,
         long viewCount,

--- a/src/main/java/com/project/post/domain/repository/dto/LecturePostListQueryResult.java
+++ b/src/main/java/com/project/post/domain/repository/dto/LecturePostListQueryResult.java
@@ -14,6 +14,7 @@ public record LecturePostListQueryResult(
         String authorDepartmentName,
         String authorRepresentativeTrackName,
         String authorTierBadgeImageUrl,
+        boolean authorWithdrawn,
         String department,
         Campus campus,
         long viewCount,

--- a/src/main/java/com/project/post/domain/repository/dto/PostDetailQueryResult.java
+++ b/src/main/java/com/project/post/domain/repository/dto/PostDetailQueryResult.java
@@ -14,6 +14,7 @@ public record PostDetailQueryResult(
         String authorDepartmentName,
         String authorRepresentativeTrackName,
         String authorTierBadgeImageUrl,
+        boolean authorWithdrawn,
         long viewCount,
         long likeCount,
         long scrapCount,

--- a/src/main/java/com/project/post/domain/repository/dto/PostListQueryResult.java
+++ b/src/main/java/com/project/post/domain/repository/dto/PostListQueryResult.java
@@ -12,6 +12,7 @@ public record PostListQueryResult(
         String authorDepartmentName,
         String authorRepresentativeTrackName,
         String authorTierBadgeImageUrl,
+        boolean authorWithdrawn,
         long viewCount,
         long likeCount,
         long scrapCount,

--- a/src/main/java/com/project/post/domain/repository/dto/PromotionPostListQueryResult.java
+++ b/src/main/java/com/project/post/domain/repository/dto/PromotionPostListQueryResult.java
@@ -15,6 +15,7 @@ public record PromotionPostListQueryResult(
         String authorDepartmentName,
         String authorRepresentativeTrackName,
         String authorTierBadgeImageUrl,
+        boolean authorWithdrawn,
         long viewCount,
         long likeCount,
         long scrapCount,

--- a/src/main/java/com/project/post/domain/repository/impl/LecturePostRepositoryImpl.java
+++ b/src/main/java/com/project/post/domain/repository/impl/LecturePostRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.project.post.domain.repository.dto.LecturePostListQueryResult;
 import com.project.post.domain.repository.dto.LecturePostSearchCondition;
 import com.project.post.domain.repository.dto.PostDetailQueryResult;
 import com.project.user.domain.repository.querydsl.UserRepresentativeTrackExpressions;
+import com.project.user.domain.repository.querydsl.UserWithdrawnExpressions;
 import com.project.user.domain.entity.QDepartment;
 import com.project.user.domain.entity.QLevelBadge;
 import com.project.user.domain.entity.QUser;
@@ -68,6 +69,7 @@ public class LecturePostRepositoryImpl implements LecturePostRepositoryCustom {
                 department.name,
                 UserRepresentativeTrackExpressions.representativeTrackNameSubquery(user),
                 levelBadge.levelImage,
+                UserWithdrawnExpressions.authorIsWithdrawn(user),
                 lecturePost.department,
                 lecturePost.campus,
                 post.viewCount,
@@ -115,6 +117,7 @@ public class LecturePostRepositoryImpl implements LecturePostRepositoryCustom {
         QDepartment department = QDepartment.department;
         QLevelBadge levelBadge = QLevelBadge.levelBadge;
         Expression<String> representativeTrackName = UserRepresentativeTrackExpressions.representativeTrackNameSubquery(user);
+        Expression<Boolean> authorWithdrawn = UserWithdrawnExpressions.authorIsWithdrawn(user);
 
         Tuple base = queryFactory
                 .select(
@@ -128,6 +131,7 @@ public class LecturePostRepositoryImpl implements LecturePostRepositoryCustom {
                         department.name,
                         representativeTrackName,
                         levelBadge.levelImage,
+                        authorWithdrawn,
                         lecturePost.department,
                         lecturePost.campus,
                         post.viewCount,
@@ -167,6 +171,7 @@ public class LecturePostRepositoryImpl implements LecturePostRepositoryCustom {
                 base.get(department.name),
                 base.get(representativeTrackName),
                 base.get(levelBadge.levelImage),
+                base.get(authorWithdrawn),
                 base.get(lecturePost.department),
                 base.get(lecturePost.campus),
                 base.get(post.viewCount),

--- a/src/main/java/com/project/post/domain/repository/impl/PostRepositoryImpl.java
+++ b/src/main/java/com/project/post/domain/repository/impl/PostRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.project.post.domain.repository.dto.PostListQueryResult;
 import com.project.post.domain.enums.PostListSort;
 import com.project.post.domain.repository.dto.PostSearchCondition;
 import com.project.user.domain.repository.querydsl.UserRepresentativeTrackExpressions;
+import com.project.user.domain.repository.querydsl.UserWithdrawnExpressions;
 import com.project.user.domain.entity.QDepartment;
 import com.project.user.domain.entity.QLevelBadge;
 import com.project.user.domain.entity.QUser;
@@ -63,6 +64,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 department.name,
                 UserRepresentativeTrackExpressions.representativeTrackNameSubquery(user),
                 levelBadge.levelImage,
+                UserWithdrawnExpressions.authorIsWithdrawn(user),
                 post.viewCount,
                 post.likeCount,
                 post.scrapCount,
@@ -106,6 +108,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         QDepartment department = QDepartment.department;
         QLevelBadge levelBadge = QLevelBadge.levelBadge;
         Expression<String> representativeTrackName = UserRepresentativeTrackExpressions.representativeTrackNameSubquery(user);
+        Expression<Boolean> authorWithdrawn = UserWithdrawnExpressions.authorIsWithdrawn(user);
 
         Tuple base = queryFactory
                 .select(
@@ -119,6 +122,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         department.name,
                         representativeTrackName,
                         levelBadge.levelImage,
+                        authorWithdrawn,
                         post.viewCount,
                         post.likeCount,
                         post.scrapCount,
@@ -144,7 +148,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         List<PostDetailQueryResult.AttachmentDto> attachments = fetchAttachments(postId);
 
         return Optional.of(buildDetailResult(
-                base, post, user, department, levelBadge, representativeTrackName, tagNames, attachments));
+                base,
+                new PostDetailTupleProjection(
+                        post, user, department, levelBadge, representativeTrackName, authorWithdrawn),
+                tagNames,
+                attachments));
     }
 
     private List<String> fetchTagNames(Long postId) {
@@ -179,13 +187,13 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     private PostDetailQueryResult buildDetailResult(
             Tuple base,
-            QPost post,
-            QUser user,
-            QDepartment department,
-            QLevelBadge levelBadge,
-            Expression<String> representativeTrackName,
+            PostDetailTupleProjection p,
             List<String> tagNames,
             List<PostDetailQueryResult.AttachmentDto> attachments) {
+        QPost post = p.post();
+        QUser user = p.user();
+        QDepartment department = p.department();
+        QLevelBadge levelBadge = p.levelBadge();
         return new PostDetailQueryResult(
                 base.get(post.id),
                 base.get(post.title),
@@ -195,8 +203,9 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 base.get(user.nickname),
                 base.get(user.profileImgUrl),
                 base.get(department.name),
-                base.get(representativeTrackName),
+                base.get(p.representativeTrackName()),
                 base.get(levelBadge.levelImage),
+                base.get(p.authorWithdrawn()),
                 base.get(post.viewCount),
                 base.get(post.likeCount),
                 base.get(post.scrapCount),
@@ -206,6 +215,15 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 tagNames,
                 attachments
         );
+    }
+
+    private record PostDetailTupleProjection(
+            QPost post,
+            QUser user,
+            QDepartment department,
+            QLevelBadge levelBadge,
+            Expression<String> representativeTrackName,
+            Expression<Boolean> authorWithdrawn) {
     }
 
     private BooleanBuilder buildPostListWhere(

--- a/src/main/java/com/project/post/domain/repository/impl/PromotionPostRepositoryImpl.java
+++ b/src/main/java/com/project/post/domain/repository/impl/PromotionPostRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.project.user.domain.entity.QDepartment;
 import com.project.user.domain.entity.QLevelBadge;
 import com.project.user.domain.entity.QUser;
 import com.project.user.domain.repository.querydsl.UserRepresentativeTrackExpressions;
+import com.project.user.domain.repository.querydsl.UserWithdrawnExpressions;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -61,6 +62,7 @@ public class PromotionPostRepositoryImpl implements PromotionPostRepositoryCusto
                 department.name,
                 UserRepresentativeTrackExpressions.representativeTrackNameSubquery(user),
                 levelBadge.levelImage,
+                UserWithdrawnExpressions.authorIsWithdrawn(user),
                 post.viewCount,
                 post.likeCount,
                 post.scrapCount,

--- a/src/main/java/com/project/user/domain/repository/querydsl/UserWithdrawnExpressions.java
+++ b/src/main/java/com/project/user/domain/repository/querydsl/UserWithdrawnExpressions.java
@@ -1,0 +1,17 @@
+package com.project.user.domain.repository.querydsl;
+
+import com.project.user.domain.entity.QUser;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+
+public final class UserWithdrawnExpressions {
+
+    private UserWithdrawnExpressions() {
+    }
+
+    public static Expression<Boolean> authorIsWithdrawn(QUser user) {
+        return new CaseBuilder()
+                .when(user.deletedAt.isNotNull()).then(true)
+                .otherwise(false);
+    }
+}

--- a/src/test/java/com/project/post/application/service/LecturePostQueryServiceTest.java
+++ b/src/test/java/com/project/post/application/service/LecturePostQueryServiceTest.java
@@ -57,6 +57,7 @@ class LecturePostQueryServiceTest {
         LecturePostListQueryResult result = new LecturePostListQueryResult(
                 1L, "알고리즘 과제", null,
                 1L, "테스터", null, "영어통번역학과", "백엔드", null,
+                false,
                 "컴퓨터공학과", Campus.SEOUL,
                 10, 5, 3, 2, Instant.now()
         );
@@ -130,6 +131,7 @@ class LecturePostQueryServiceTest {
         LecturePostDetailQueryResult result = new LecturePostDetailQueryResult(
                 1L, "제목", "본문", null,
                 10L, "닉네임", null, null, null, null,
+                false,
                 "컴퓨터공학과", Campus.SEOUL,
                 100, 50, 30, 20,
                 Instant.now(), Instant.now(),

--- a/src/test/java/com/project/post/application/service/PostCommentQueryServiceTest.java
+++ b/src/test/java/com/project/post/application/service/PostCommentQueryServiceTest.java
@@ -111,6 +111,8 @@ class PostCommentQueryServiceTest {
         assertThat(rootResponse.replies().get(0).parentCommentId()).isEqualTo(10L);
         assertThat(rootResponse.replies().get(0).content()).isEqualTo("reply");
         assertThat(rootResponse.isDeleted()).isFalse();
+        assertThat(rootResponse.isWithdrawn()).isFalse();
+        assertThat(rootResponse.replies().get(0).isWithdrawn()).isFalse();
         assertThat(rootResponse.hasMoreReplies()).isFalse();
         assertThat(rootResponse.viewer()).isEqualTo(CommentViewerResponse.guest());
         assertThat(rootResponse.replies().get(0).viewer()).isEqualTo(CommentViewerResponse.guest());
@@ -141,6 +143,7 @@ class PostCommentQueryServiceTest {
         assertThat(rootResponse.content()).isNull();
         assertThat(rootResponse.userId()).isNull();
         assertThat(rootResponse.userNickname()).isNull();
+        assertThat(rootResponse.isWithdrawn()).isFalse();
         assertThat(rootResponse.hasMoreReplies()).isFalse();
 
         @SuppressWarnings("unchecked")
@@ -152,14 +155,9 @@ class PostCommentQueryServiceTest {
     // ── 탈퇴 사용자가 댓글 작성자인 경우 ──────────────────────────────────────
 
     /**
-     * 시나리오 1: 탈퇴 사용자가 댓글 작성자인 상태에서 댓글 목록 API 호출.
-     *
-     * PostCommentQueryServiceImpl.toResponse()는 비삭제 댓글에서 comment.getUser().getNickname()을 호출한다.
-     * @SQLRestriction 제거 전: User.user lazy-load 시 deleted_at IS NULL 조건에 걸려
-     * EntityNotFoundException 위험이 있었다.
-     * 제거 후: 익명화된 User 행(nickname="탈퇴한 회원")이 정상 로드되어 DTO에 반영되어야 한다.
-     *
-     * 삭제된 댓글(isDeleted=true)은 기존 마스킹 로직이 처리하므로 이 케이스와 별개다.
+     * 탈퇴 사용자가 작성자인 비삭제 댓글: 엔티티 연관 User 를 로드해 닉네임·{@link PostCommentResponse#isWithdrawn()} 을 채운다.
+     * {@code User.withdraw()} 는 닉네임을 비우고 soft-delete 하므로 닉네임은 null이 될 수 있다.
+     * 삭제된 댓글({@code isDeleted=true})은 작성자 마스킹·isWithdrawn=false 규칙이 별도다.
      */
     @Nested
     @DisplayName("탈퇴 사용자가 댓글 작성자인 경우")
@@ -171,13 +169,13 @@ class PostCommentQueryServiceTest {
         @BeforeEach
         void setUpWithdrawn() {
             withdrawnUser = buildUser(99L, "original");
-            withdrawnUser.withdraw(); // nickname → "탈퇴한 회원", deletedAt 설정
+            withdrawnUser.withdraw(); // 닉네임 null, deletedAt 설정(탈퇴)
             post = buildPost(1L, withdrawnUser);
             ReflectionTestUtils.setField(post, "commentCount", 1L);
         }
 
         @Test
-        @DisplayName("비삭제 댓글의 탈퇴 작성자 닉네임이 '탈퇴한 회원'으로 표시되고 댓글 내용은 유지된다")
+        @DisplayName("비삭제 댓글의 탈퇴 작성자: 닉네임 null·isWithdrawn true, 본문은 유지")
         void getCommentsShowsWithdrawnAuthorNicknameOnActiveComment() {
             PostComment root = PostComment.createRoot(post, withdrawnUser, "댓글 내용");
             ReflectionTestUtils.setField(root, "id", 10L);
@@ -196,6 +194,7 @@ class PostCommentQueryServiceTest {
             assertThat(response.isDeleted()).isFalse();        // 댓글 자체는 삭제되지 않음
             assertThat(response.userId()).isEqualTo(99L);      // FK는 여전히 유효
             assertThat(response.userNickname()).isEqualTo(null);
+            assertThat(response.isWithdrawn()).isTrue();
             assertThat(response.content()).isEqualTo("댓글 내용"); // 내용은 그대로 표시
         }
 
@@ -212,13 +211,12 @@ class PostCommentQueryServiceTest {
                     eq(1L), eq(List.of(10L)), eq(PostConstants.REPLY_PREVIEW_LIMIT + 1)))
                     .thenReturn(List.of());
 
-            // @SQLRestriction 제거 전이라면 comment.getUser() 로딩 시 EntityNotFoundException 발생 위치
             assertThatCode(() -> postCommentQueryService.getComments(1L, null, 10, null))
                     .doesNotThrowAnyException();
         }
 
         @Test
-        @DisplayName("탈퇴 사용자의 답글 닉네임이 '탈퇴한 회원'으로 표시된다")
+        @DisplayName("탈퇴 사용자의 답글: 닉네임 null·isWithdrawn true")
         void getCommentsShowsWithdrawnAuthorInReply() {
             User activeRootAuthor = buildUser(1L, "activeUser");
             Post postByActive = buildPost(1L, activeRootAuthor);
@@ -243,12 +241,14 @@ class PostCommentQueryServiceTest {
 
             PostCommentResponse rootResponse = result.comments().get(0);
             assertThat(rootResponse.userNickname()).isEqualTo("activeUser"); // 루트 작성자는 정상
+            assertThat(rootResponse.isWithdrawn()).isFalse();
             assertThat(rootResponse.replies()).hasSize(1);
 
             PostCommentResponse replyResponse = rootResponse.replies().get(0);
             assertThat(replyResponse.isDeleted()).isFalse();
             assertThat(replyResponse.userId()).isEqualTo(99L);
             assertThat(replyResponse.userNickname()).isEqualTo(null);
+            assertThat(replyResponse.isWithdrawn()).isTrue();
             assertThat(replyResponse.content()).isEqualTo("탈퇴자의 답글");
             assertThat(replyResponse.parentCommentId()).isEqualTo(10L);
         }
@@ -280,10 +280,12 @@ class PostCommentQueryServiceTest {
             assertThat(withdrawnResponse.userNickname()).isEqualTo(null);
             assertThat(withdrawnResponse.userId()).isEqualTo(99L);
             assertThat(withdrawnResponse.isDeleted()).isFalse();
+            assertThat(withdrawnResponse.isWithdrawn()).isTrue();
 
             PostCommentResponse activeResponse = result.comments().get(1);
             assertThat(activeResponse.userNickname()).isEqualTo("activeUser");
             assertThat(activeResponse.isDeleted()).isFalse();
+            assertThat(activeResponse.isWithdrawn()).isFalse();
         }
 
         @Test

--- a/src/test/java/com/project/post/application/service/PostQueryServiceTest.java
+++ b/src/test/java/com/project/post/application/service/PostQueryServiceTest.java
@@ -105,6 +105,7 @@ class PostQueryServiceTest {
                 null,
                 null,
                 null,
+                false,
                 3L,
                 2L,
                 1L,
@@ -136,7 +137,7 @@ class PostQueryServiceTest {
         when(boardRepository.findByCodeAndActiveTrue("GENERAL")).thenReturn(Optional.of(Board.of("GENERAL", "자유/정보 게시판")));
 
         Page<PostListQueryResult> queryPage = new PageImpl<>(Objects.requireNonNull(List.of(
-                new PostListQueryResult(1L, "t", "thumb", 1L, "nick", null, null, null, null, 0, 0, 0, 0, Instant.now())
+                new PostListQueryResult(1L, "t", "thumb", 1L, "nick", null, null, null, null, false, 0, 0, 0, 0, Instant.now())
         )));
         PostSearchCondition condition = new PostSearchCondition(null, null, PostListSort.LATEST);
         Pageable pageable = PageRequest.of(0, 10);
@@ -156,12 +157,9 @@ class PostQueryServiceTest {
     // ── 탈퇴 사용자가 게시글 작성자인 경우 ──────────────────────────────────────
 
     /**
-     * 시나리오 1: 탈퇴 사용자가 작성자인 게시글 목록/상세 API 호출.
-     *
-     * PostQueryServiceImpl은 QueryDSL 프로젝션(PostListQueryResult, PostDetailQueryResult)을 사용하므로
-     * User 엔티티를 직접 lazy-load하지 않는다. 탈퇴 처리 후 User 행은 익명화된 값으로 남아 있고,
-     * JOIN 결과에 authorNickname="탈퇴한 회원", profileImgUrl=null 등이 들어온다.
-     * DTO 매핑 레이어가 이 값들을 예외 없이 올바르게 반환하는지 검증한다.
+     * 탈퇴 사용자가 작성자인 게시글 목록/상세: 레포지토리 프로젝션 결과를 그대로 API로 매핑한다.
+     * {@code User.withdraw()} 는 닉네임 등을 비우고 {@code deleted_at} 을 설정하며,
+     * 탈퇴 여부는 {@code authorWithdrawn} 과 {@link PostAuthorResponse#isWithdrawn()} 으로 전달된다.
      */
     @Nested
     @DisplayName("탈퇴 사용자가 게시글 작성자인 경우")
@@ -170,15 +168,16 @@ class PostQueryServiceTest {
         private static final Long WITHDRAWN_AUTHOR_ID = 99L;
 
         @Test
-        @DisplayName("목록 조회: 탈퇴한 작성자 닉네임이 '탈퇴한 회원', 익명화된 null 필드도 정상 매핑된다")
+        @DisplayName("목록 조회: 탈퇴 작성자는 닉네임 등 null·authorWithdrawn=true 가 매핑된다")
         void getListWithWithdrawnAuthorMapsAnonymizedFields() {
             when(boardRepository.findByCodeAndActiveTrue("GENERAL"))
                     .thenReturn(Optional.of(Board.of("GENERAL", "자유/정보 게시판")));
 
-            // User.withdraw() 후 DB 행 상태: nickname="탈퇴한 회원", profileImgUrl=null, department=null
+            // withdraw() 이후 DB/프로젝션에 가깝게: nickname null, authorWithdrawn true
             PostListQueryResult result = new PostListQueryResult(
                     1L, "title", null,
                     WITHDRAWN_AUTHOR_ID, null, null, null, null, null,
+                    true,
                     0, 0, 0, 0, Instant.now()
             );
             Page<PostListQueryResult> queryPage = new PageImpl<>(List.of(result));
@@ -201,6 +200,7 @@ class PostQueryServiceTest {
             assertThat(author.profileImageUrl()).isNull();
             assertThat(author.departmentName()).isNull();
             assertThat(author.representativeTrackName()).isNull();
+            assertThat(author.isWithdrawn()).isTrue();
         }
 
         @Test
@@ -212,6 +212,7 @@ class PostQueryServiceTest {
             PostListQueryResult result = new PostListQueryResult(
                     1L, "title", null,
                     WITHDRAWN_AUTHOR_ID, null, null, null, null, null,
+                    true,
                     0, 0, 0, 0, Instant.now()
             );
             when(postRepository.findPostList(eq("GENERAL"), any(Pageable.class), any(PostSearchCondition.class)))
@@ -225,11 +226,12 @@ class PostQueryServiceTest {
         }
 
         @Test
-        @DisplayName("상세 조회: 탈퇴한 작성자 닉네임이 '탈퇴한 회원', 익명화된 null 필드도 정상 매핑된다")
+        @DisplayName("상세 조회: 탈퇴 작성자는 닉네임 등 null·isWithdrawn=true 가 매핑된다")
         void getDetailWithWithdrawnAuthorMapsAnonymizedFields() {
             PostDetailQueryResult result = new PostDetailQueryResult(
                     1L, "title", "content", null,
-                    WITHDRAWN_AUTHOR_ID, "탈퇴한 회원", null, null, null, null,
+                    WITHDRAWN_AUTHOR_ID, null, null, null, null, null,
+                    true,
                     0L, 5L, 2L, 3L,
                     Instant.now(), Instant.now(),
                     List.of(), List.of()
@@ -243,10 +245,11 @@ class PostQueryServiceTest {
             PostDetailResponse response = postQueryService.getDetail(1L, null);
 
             assertThat(response.author().authorId()).isEqualTo(WITHDRAWN_AUTHOR_ID);
-            assertThat(response.author().nickname()).isEqualTo("탈퇴한 회원");
+            assertThat(response.author().nickname()).isNull();
             assertThat(response.author().profileImageUrl()).isNull();
             assertThat(response.author().departmentName()).isNull();
             assertThat(response.author().representativeTrackName()).isNull();
+            assertThat(response.author().isWithdrawn()).isTrue();
             // 게시글 카운트는 그대로 유지
             assertThat(response.likeCount()).isEqualTo(5L);
             assertThat(response.scrapCount()).isEqualTo(2L);
@@ -257,7 +260,8 @@ class PostQueryServiceTest {
         void getDetailDoesNotThrowForWithdrawnAuthor() {
             PostDetailQueryResult result = new PostDetailQueryResult(
                     1L, "title", "content", null,
-                    WITHDRAWN_AUTHOR_ID, "탈퇴한 회원", null, null, null, null,
+                    WITHDRAWN_AUTHOR_ID, null, null, null, null, null,
+                    true,
                     0L, 0L, 0L, 0L,
                     Instant.now(), Instant.now(),
                     List.of(), List.of()
@@ -268,8 +272,6 @@ class PostQueryServiceTest {
                     isNull(), eq(List.of(1L)), eq(Map.of(1L, WITHDRAWN_AUTHOR_ID))))
                     .thenReturn(Map.of(1L, PostViewerResponse.guest()));
 
-            // @SQLRestriction 제거 전이라면 JOIN FETCH 경로에서 예외 발생 가능 위치.
-            // 프로젝션 방식이므로 직접적인 영향은 없으나, 쿼리 JOIN 결과가 올바르게 매핑됨을 보장
             org.assertj.core.api.Assertions.assertThatCode(
                     () -> postQueryService.getDetail(1L, null)
             ).doesNotThrowAnyException();


### PR DESCRIPTION
## 📌 관련 이슈
- closes #67 

## ✨ 작업 내용
- 게시글(일반·강의·홍보) 작성자 응답에 탈퇴 여부 isWithdrawn을 추가하고, 댓글 응답에도 동일 필드를 추가했다.
- QueryDSL 프로젝션·PostAuthorMapper·PostRepositoryImpl Tuple 경로 묶음 등으로 조회 매핑을 정리하고 Checkstyle ParameterNumber 위반을 해소했다.

## 🔍 주요 변경 사항

- PostAuthorResponse / 리포지토리 조회 DTO에 authorWithdrawn·isWithdrawn 반영, UserWithdrawnExpressions로 deleted_at 기준 프로젝션
- PostCommentResponse에 isWithdrawn 추가 및 PostCommentQueryServiceImpl 매핑
- PostAuthorMapper 도입으로 조회 서비스의 PostAuthorResponse 조립 중복 제거
- PostRepositoryImpl 상세 조회: PostDetailTupleProjection으로 파라미터 개수 제한 충족
- 탈퇴 시나리오 테스트·주석을 현재 withdraw()·닉네임 null 동작에 맞게 수정

## 🧪 테스트 여부
- [x] 로컬 테스트 완료
- [ ] 테스트 코드 추가 / 수정
- [ ] 테스트 없음 (이유: )

## 🤖 리뷰 포인트
- 확인이 필요한 부분이 있다면 작성

## ⚠️ 참고 사항
- 리뷰어가 알면 좋은 맥락이나 주의사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  - 게시물 및 댓글에서 탈퇴한 작성자 상태를 표시합니다.

* **개선 사항**
  - 작성자 정보 처리 로직을 최적화하여 더 일관된 데이터 관리를 제공합니다.

* **테스트**
  - 탈퇴 사용자 상태 표시 기능에 대한 테스트 케이스를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->