### PR TITLE
feat: 랭킹 스냅샷 배치·조회 API 및 테스트 추가

### DIFF
--- a/src/main/java/com/project/contribution/policy/ContributionPolicy.java
+++ b/src/main/java/com/project/contribution/policy/ContributionPolicy.java
@@ -6,9 +6,6 @@ import com.project.global.event.ActivityType;
 
 import java.util.List;
 
-/**
- * 활동 맥락에 따라 지급·회수 명령 목록을 반환한다 (§24.7). DB에 직접 쓰지 않는다.
- */
 public interface ContributionPolicy {
 
     boolean supports(ActivityType activityType);

--- a/src/main/java/com/project/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/global/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/lectures/{id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/promotions").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/promotions/{postId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/rankings").permitAll()
                         // 그 외 모든 요청은 인증 필요 (Redis 세션 기반 인증 적용 예정)
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/project/ranking/application/dto/RankingEntryResponse.java
+++ b/src/main/java/com/project/ranking/application/dto/RankingEntryResponse.java
@@ -1,0 +1,13 @@
+package com.project.ranking.application.dto;
+
+public record RankingEntryResponse(
+        int displayRank,
+        Integer originalRank,
+        long score,
+        long userId,
+        String nickname,
+        String departmentName,
+        String levelBadgeImageUrl,
+        boolean isMe
+) {
+}

--- a/src/main/java/com/project/ranking/application/dto/RankingListResponse.java
+++ b/src/main/java/com/project/ranking/application/dto/RankingListResponse.java
@@ -1,0 +1,10 @@
+package com.project.ranking.application.dto;
+
+import java.util.List;
+
+public record RankingListResponse(
+        RankingMetaResponse meta,
+        RankingPageInfo page,
+        List<RankingEntryResponse> content
+) {
+}

--- a/src/main/java/com/project/ranking/application/dto/RankingMeResponse.java
+++ b/src/main/java/com/project/ranking/application/dto/RankingMeResponse.java
@@ -1,0 +1,22 @@
+package com.project.ranking.application.dto;
+
+import com.project.ranking.domain.RankingPeriodType;
+
+import java.time.Instant;
+
+public record RankingMeResponse(
+        RankingPeriodType periodType,
+        String periodKey,
+        Instant calculatedAt,
+        Instant periodStart,
+        Instant periodEnd,
+        boolean isRealtime,
+        int displayRank,
+        Integer originalRank,
+        long score,
+        long userId,
+        String nickname,
+        String departmentName,
+        String levelBadgeImageUrl
+) {
+}

--- a/src/main/java/com/project/ranking/application/dto/RankingMetaResponse.java
+++ b/src/main/java/com/project/ranking/application/dto/RankingMetaResponse.java
@@ -1,25 +1,30 @@
-package com.project.ranking.application.dto;
-
-import com.project.ranking.domain.RankingPeriodType;
-
-import java.time.Instant;
-
-public record RankingMetaResponse(
-        RankingPeriodType periodType,
-        String periodKey,
-        Instant calculatedAt,
-        Instant periodStart,
-        Instant periodEnd,
-        boolean isRealtime,
-        boolean snapshotAvailable
-) {
-    public static RankingMetaResponse of(
-            RankingPeriodType periodType,
-            String periodKey,
-            Instant calculatedAt,
-            Instant periodStart,
-            Instant periodEnd) {
-        boolean snapshotAvailable = calculatedAt != null;
-        return new RankingMetaResponse(periodType, periodKey, calculatedAt, periodStart, periodEnd, false, snapshotAvailable);
-    }
-}
+package com.project.ranking.application.dto;
+
+import com.project.ranking.domain.RankingPeriodType;
+
+import java.time.Instant;
+
+/**
+ * @param periodStart 집계 구간 하한(inclusive). ALL_TIME에서는 null일 수 있음.
+ * @param periodEnd   집계 구간 상한. 배치·원장 필터의 {@code occurred_at < periodEnd}와 동일한 <strong>exclusive</strong> 시각.
+ */
+public record RankingMetaResponse(
+        RankingPeriodType periodType,
+        String periodKey,
+        Instant calculatedAt,
+        Instant periodStart,
+        Instant periodEnd,
+        boolean isRealtime,
+        boolean snapshotAvailable
+) {
+
+    public static RankingMetaResponse of(
+            RankingPeriodType periodType,
+            String periodKey,
+            Instant calculatedAt,
+            Instant periodStart,
+            Instant periodEnd) {
+        boolean snapshotAvailable = calculatedAt != null;
+        return new RankingMetaResponse(periodType, periodKey, calculatedAt, periodStart, periodEnd, false, snapshotAvailable);
+    }
+}

--- a/src/main/java/com/project/ranking/application/dto/RankingMetaResponse.java
+++ b/src/main/java/com/project/ranking/application/dto/RankingMetaResponse.java
@@ -1,0 +1,25 @@
+package com.project.ranking.application.dto;
+
+import com.project.ranking.domain.RankingPeriodType;
+
+import java.time.Instant;
+
+public record RankingMetaResponse(
+        RankingPeriodType periodType,
+        String periodKey,
+        Instant calculatedAt,
+        Instant periodStart,
+        Instant periodEnd,
+        boolean isRealtime,
+        boolean snapshotAvailable
+) {
+    public static RankingMetaResponse of(
+            RankingPeriodType periodType,
+            String periodKey,
+            Instant calculatedAt,
+            Instant periodStart,
+            Instant periodEnd) {
+        boolean snapshotAvailable = calculatedAt != null;
+        return new RankingMetaResponse(periodType, periodKey, calculatedAt, periodStart, periodEnd, false, snapshotAvailable);
+    }
+}

--- a/src/main/java/com/project/ranking/application/dto/RankingPageInfo.java
+++ b/src/main/java/com/project/ranking/application/dto/RankingPageInfo.java
@@ -1,0 +1,9 @@
+package com.project.ranking.application.dto;
+
+public record RankingPageInfo(
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/project/ranking/application/service/RankingMetaFactory.java
+++ b/src/main/java/com/project/ranking/application/service/RankingMetaFactory.java
@@ -8,15 +8,13 @@ import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.YearMonth;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
+/**
+ * API 메타의 기간 경계는 {@link RankingPeriodKeys}의 inclusive/exclusive 시각과 동일해야 한다.
+ */
 @Component
 public class RankingMetaFactory {
-
-    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     public RankingMetaResponse build(RankingPeriodType periodType, String periodKey, Instant calculatedAt) {
         return switch (periodType) {
@@ -24,14 +22,14 @@ public class RankingMetaFactory {
             case WEEKLY -> {
                 LocalDate monday = RankingPeriodKeys.parseWeekMondayOrThrow(periodKey);
                 Instant start = RankingPeriodKeys.weekStartInclusive(monday);
-                ZonedDateTime sundayEnd = monday.plusDays(6).atTime(LocalTime.MAX).atZone(SEOUL);
-                yield RankingMetaResponse.of(periodType, periodKey, calculatedAt, start, sundayEnd.toInstant());
+                Instant endExclusive = RankingPeriodKeys.weekEndExclusive(monday);
+                yield RankingMetaResponse.of(periodType, periodKey, calculatedAt, start, endExclusive);
             }
             case MONTHLY -> {
                 YearMonth ym = RankingPeriodKeys.parseYearMonthOrThrow(periodKey);
                 Instant start = RankingPeriodKeys.monthStartInclusive(ym);
-                ZonedDateTime monthEnd = ym.atEndOfMonth().atTime(LocalTime.MAX).atZone(SEOUL);
-                yield RankingMetaResponse.of(periodType, periodKey, calculatedAt, start, monthEnd.toInstant());
+                Instant endExclusive = RankingPeriodKeys.monthEndExclusive(ym);
+                yield RankingMetaResponse.of(periodType, periodKey, calculatedAt, start, endExclusive);
             }
         };
     }

--- a/src/main/java/com/project/ranking/application/service/RankingMetaFactory.java
+++ b/src/main/java/com/project/ranking/application/service/RankingMetaFactory.java
@@ -1,0 +1,38 @@
+package com.project.ranking.application.service;
+
+import com.project.ranking.application.dto.RankingMetaResponse;
+import com.project.ranking.application.support.RankingPeriodKeys;
+import com.project.ranking.domain.RankingPeriodType;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Component
+public class RankingMetaFactory {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    public RankingMetaResponse build(RankingPeriodType periodType, String periodKey, Instant calculatedAt) {
+        return switch (periodType) {
+            case ALL_TIME -> RankingMetaResponse.of(periodType, periodKey, calculatedAt, null, calculatedAt);
+            case WEEKLY -> {
+                LocalDate monday = RankingPeriodKeys.parseWeekMondayOrThrow(periodKey);
+                Instant start = RankingPeriodKeys.weekStartInclusive(monday);
+                ZonedDateTime sundayEnd = monday.plusDays(6).atTime(LocalTime.MAX).atZone(SEOUL);
+                yield RankingMetaResponse.of(periodType, periodKey, calculatedAt, start, sundayEnd.toInstant());
+            }
+            case MONTHLY -> {
+                YearMonth ym = RankingPeriodKeys.parseYearMonthOrThrow(periodKey);
+                Instant start = RankingPeriodKeys.monthStartInclusive(ym);
+                ZonedDateTime monthEnd = ym.atEndOfMonth().atTime(LocalTime.MAX).atZone(SEOUL);
+                yield RankingMetaResponse.of(periodType, periodKey, calculatedAt, start, monthEnd.toInstant());
+            }
+        };
+    }
+}

--- a/src/main/java/com/project/ranking/application/service/RankingQueryService.java
+++ b/src/main/java/com/project/ranking/application/service/RankingQueryService.java
@@ -1,0 +1,236 @@
+package com.project.ranking.application.service;
+
+import com.project.global.error.BusinessException;
+import com.project.global.error.ErrorCode;
+import com.project.ranking.application.dto.RankingEntryResponse;
+import com.project.ranking.application.dto.RankingListResponse;
+import com.project.ranking.application.dto.RankingMeResponse;
+import com.project.ranking.application.dto.RankingMetaResponse;
+import com.project.ranking.application.dto.RankingPageInfo;
+import com.project.ranking.application.support.RankingPeriodKeys;
+import com.project.ranking.config.RankingProperties;
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.ranking.domain.repository.RankingSnapshotRepository;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 랭킹 목록·내 순위 조회.
+ * <p>
+ * {@code displayRank}: 탈퇴자를 제외한 뒤 {@code score}만 기준으로 한 표준 SQL {@code RANK()}
+ * (동점은 동일 순위, 다음 순위는 간격 있음 — 예: 1,2,2,4).
+ * 동점 구간 내 표시 순서는 목록 쿼리에서 {@code user_id ASC}로 고정한다.
+ * 운영(PostgreSQL)은 {@link RankingProperties#isUseWindowRankSql()} 가 true일 때 윈도우 함수,
+ * 테스트(H2) 등에서는 동일 의미의 대체식을 쓴다. 목록과 COUNT는 동일 {@code filtered} CTE를 쓴다.
+ */
+@Service
+public class RankingQueryService {
+
+    private final NamedParameterJdbcTemplate jdbc;
+    private final RankingSnapshotRepository snapshotRepository;
+    private final RankingMetaFactory metaFactory;
+    private final RankingProperties rankingProperties;
+    private final String listSql;
+    private final String meSql;
+
+    public RankingQueryService(
+            NamedParameterJdbcTemplate jdbc,
+            RankingSnapshotRepository snapshotRepository,
+            RankingMetaFactory metaFactory,
+            RankingProperties rankingProperties) {
+        this.jdbc = jdbc;
+        this.snapshotRepository = snapshotRepository;
+        this.metaFactory = metaFactory;
+        this.rankingProperties = rankingProperties;
+        String filteredCte = buildFilteredCte(rankingProperties);
+        this.listSql = filteredCte + LIST_SQL_SUFFIX;
+        this.meSql = filteredCte + ME_SQL_SUFFIX;
+    }
+
+    @Transactional(readOnly = true)
+    public RankingListResponse list(
+            RankingPeriodType periodType,
+            String periodKeyOrNull,
+            int page,
+            int size,
+            Long currentUserIdOrNull) {
+        int cappedSize = Math.min(Math.max(1, size), rankingProperties.getMaxPageSize());
+        int zeroBasedPage = Math.max(0, page);
+        String periodKey = resolvePeriodKey(periodType, periodKeyOrNull);
+        Optional<Instant> calculatedAtOpt = snapshotRepository.findMaxCalculatedAt(periodType, periodKey);
+        Instant calculatedAt = calculatedAtOpt.orElse(null);
+        RankingMetaResponse meta = metaFactory.build(periodType, periodKey, calculatedAt);
+
+        long total = countFiltered(periodType, periodKey);
+        int totalPages = cappedSize == 0 ? 0 : (int) Math.ceil((double) total / (double) cappedSize);
+        int offset = zeroBasedPage * cappedSize;
+
+        MapSqlParameterSource p = baseParams(periodType, periodKey)
+                .addValue("limit", cappedSize)
+                .addValue("offset", offset);
+
+        List<RankingEntryResponse> rows = jdbc.query(listSql, p, listRowMapper(currentUserIdOrNull));
+
+        RankingPageInfo pageInfo = new RankingPageInfo(zeroBasedPage, cappedSize, total, totalPages);
+        return new RankingListResponse(meta, pageInfo, rows);
+    }
+
+    @Transactional(readOnly = true)
+    public RankingMeResponse myRank(
+            RankingPeriodType periodType,
+            String periodKeyOrNull,
+            long userId) {
+        String periodKey = resolvePeriodKey(periodType, periodKeyOrNull);
+        Optional<Instant> calculatedAtOpt = snapshotRepository.findMaxCalculatedAt(periodType, periodKey);
+        Instant calculatedAt = calculatedAtOpt.orElseThrow(
+                () -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "랭킹 스냅샷이 없습니다."));
+        RankingMetaResponse meta = metaFactory.build(periodType, periodKey, calculatedAt);
+
+        MapSqlParameterSource p = baseParams(periodType, periodKey).addValue("meUserId", userId);
+        List<RankingMeResponse> rows = jdbc.query(meSql, p, (rs, rowNum) -> mapMe(rs, meta));
+        if (rows.isEmpty()) {
+            throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "해당 기간 랭킹에 포함되지 않았습니다.");
+        }
+        return rows.getFirst();
+    }
+
+    private long countFiltered(RankingPeriodType periodType, String periodKey) {
+        Long c = jdbc.queryForObject(COUNT_SQL, baseParams(periodType, periodKey), Long.class);
+        return c != null ? c : 0L;
+    }
+
+    private static MapSqlParameterSource baseParams(RankingPeriodType periodType, String periodKey) {
+        return new MapSqlParameterSource()
+                .addValue("pt", periodType.name())
+                .addValue("pk", periodKey);
+    }
+
+    private String resolvePeriodKey(RankingPeriodType periodType, String periodKeyOrNull) {
+        if (periodKeyOrNull != null && !periodKeyOrNull.isBlank()) {
+            return validateProvidedKey(periodType, periodKeyOrNull.trim());
+        }
+        LocalDate today = RankingPeriodKeys.todaySeoul();
+        return switch (periodType) {
+            case ALL_TIME -> RankingPeriodKeys.ALL_TIME_KEY;
+            case WEEKLY -> RankingPeriodKeys.defaultWeeklyPeriodKey(today);
+            case MONTHLY -> RankingPeriodKeys.defaultMonthlyPeriodKey(today);
+        };
+    }
+
+    private static String validateProvidedKey(RankingPeriodType periodType, String key) {
+        return switch (periodType) {
+            case ALL_TIME -> {
+                if (!RankingPeriodKeys.ALL_TIME_KEY.equals(key)) {
+                    throw new BusinessException(ErrorCode.INVALID_INPUT, "ALL_TIME period_key는 ALL 이어야 합니다.");
+                }
+                yield key;
+            }
+            case WEEKLY -> {
+                RankingPeriodKeys.parseWeekMondayOrThrow(key);
+                yield key;
+            }
+            case MONTHLY -> {
+                RankingPeriodKeys.parseYearMonthOrThrow(key);
+                yield key;
+            }
+        };
+    }
+
+    private static RowMapper<RankingEntryResponse> listRowMapper(Long currentUserIdOrNull) {
+        return (rs, rowNum) -> new RankingEntryResponse(
+                rs.getInt("display_rank"),
+                rs.getObject("snapshot_rank") != null ? rs.getInt("snapshot_rank") : null,
+                rs.getLong("score"),
+                rs.getLong("user_id"),
+                rs.getString("nickname"),
+                rs.getString("department_name"),
+                rs.getString("level_badge_image"),
+                currentUserIdOrNull != null && currentUserIdOrNull == rs.getLong("user_id"));
+    }
+
+    private static RankingMeResponse mapMe(ResultSet rs, RankingMetaResponse meta) throws SQLException {
+        return new RankingMeResponse(
+                meta.periodType(),
+                meta.periodKey(),
+                meta.calculatedAt(),
+                meta.periodStart(),
+                meta.periodEnd(),
+                meta.isRealtime(),
+                rs.getInt("display_rank"),
+                rs.getObject("snapshot_rank") != null ? rs.getInt("snapshot_rank") : null,
+                rs.getLong("score"),
+                rs.getLong("user_id"),
+                rs.getString("nickname"),
+                rs.getString("department_name"),
+                rs.getString("level_badge_image"));
+    }
+
+    private static String buildFilteredCte(RankingProperties rankingProperties) {
+        String rankedInner = rankingProperties.isUseWindowRankSql()
+                ? """
+                SELECT f.*,
+                       RANK() OVER (ORDER BY f.score DESC) AS display_rank
+                FROM filtered f
+                """
+                : """
+                SELECT f.*,
+                       (1 + (SELECT COUNT(*) FROM filtered f2 WHERE f2.score > f.score)) AS display_rank
+                FROM filtered f
+                """;
+        return """
+                WITH filtered AS (
+                    SELECT rs.user_id, rs.score, rs.snapshot_rank, rs.calculated_at
+                    FROM ranking_snapshot rs
+                    INNER JOIN users u ON u.user_id = rs.user_id AND u.deleted_at IS NULL
+                    WHERE rs.period_type = :pt AND rs.period_key = :pk
+                ),
+                ranked AS (
+                """
+                + rankedInner
+                + """
+                )
+                """;
+    }
+
+    private static final String COUNT_SQL = """
+            WITH filtered AS (
+                SELECT rs.user_id
+                FROM ranking_snapshot rs
+                INNER JOIN users u ON u.user_id = rs.user_id AND u.deleted_at IS NULL
+                WHERE rs.period_type = :pt AND rs.period_key = :pk
+            )
+            SELECT COUNT(*) FROM filtered
+            """;
+
+    private static final String LIST_SQL_SUFFIX = """
+            SELECT r.display_rank, r.score, r.snapshot_rank, r.user_id, u.nickname,
+                   d.name AS department_name, lb.level_image AS level_badge_image
+            FROM ranked r
+            INNER JOIN users u ON u.user_id = r.user_id
+            LEFT JOIN departments d ON d.department_id = u.department_id
+            LEFT JOIN level_badge lb ON lb.id = u.level_id
+            ORDER BY r.display_rank ASC, r.user_id ASC
+            LIMIT :limit OFFSET :offset
+            """;
+
+    private static final String ME_SQL_SUFFIX = """
+            SELECT r.display_rank, r.score, r.snapshot_rank, r.user_id, u.nickname,
+                   d.name AS department_name, lb.level_image AS level_badge_image
+            FROM ranked r
+            INNER JOIN users u ON u.user_id = r.user_id
+            LEFT JOIN departments d ON d.department_id = u.department_id
+            LEFT JOIN level_badge lb ON lb.id = u.level_id
+            WHERE r.user_id = :meUserId
+            """;
+}

--- a/src/main/java/com/project/ranking/application/service/RankingSnapshotBatchService.java
+++ b/src/main/java/com/project/ranking/application/service/RankingSnapshotBatchService.java
@@ -1,44 +1,36 @@
 package com.project.ranking.application.service;
 
 import com.project.ranking.application.support.RankingPeriodKeys;
-import com.project.ranking.domain.RankingPeriodType;
-import com.project.ranking.infrastructure.persistence.RankingSnapshotJdbcRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 
 /**
- * 일 배치 — 스테이징 적재 → 본 테이블 프로모션. 동일 period 재실행 시 결과 대체.
- * <p>
- * {@link #runDailySnapshotBatch}는 단일 트랜잭션으로 전체·주·월 갱신을 묶어,
- * 기간별 {@code promoteStagingToMain}(DELETE 후 INSERT … SELECT)가 중간에 끊기면
- * 해당 period 본 테이블이 비는 상태가 되지 않도록 한다. 단건 {@code rebuild*} 호출도
- * 각 메서드의 {@code @Transactional}으로 동일하게 한 트랜잭션에서 스테이징 정리까지 완료한다.
+ * 일 배치 오케스트레이션: 서울 기준 날짜·주·월 키 계산과 ALL_TIME → WEEKLY → MONTHLY 실행 순서만 담당한다.
+ * 트랜잭션·락·스테이징/프로모션은 {@link RankingSnapshotRebuildService}에 위임한다.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankingSnapshotBatchService {
 
-    private final RankingSnapshotJdbcRepository jdbc;
+    private final RankingSnapshotRebuildService rebuildService;
 
     /**
      * 매일 실행: 전체·직전 완료 주·직전 완료 월 스냅샷을 갱신한다.
      */
-    @Transactional
     public void runDailySnapshotBatch(Instant calculatedAt) {
         LocalDate today = RankingPeriodKeys.todaySeoul();
-        rebuildAllTime(calculatedAt);
+        rebuildService.rebuildAllTime(calculatedAt);
 
         LocalDate lastWeekMon = RankingPeriodKeys.lastCompletedWeekMonday(today);
         String weekKey = RankingPeriodKeys.formatWeekKey(lastWeekMon);
-        rebuildWeekly(
+        rebuildService.rebuildWeekly(
                 weekKey,
                 RankingPeriodKeys.weekStartInclusive(lastWeekMon),
                 RankingPeriodKeys.weekEndExclusive(lastWeekMon),
@@ -46,7 +38,7 @@ public class RankingSnapshotBatchService {
 
         YearMonth prevMonth = YearMonth.from(today).minusMonths(1);
         String monthKey = prevMonth.toString();
-        rebuildMonthly(
+        rebuildService.rebuildMonthly(
                 monthKey,
                 RankingPeriodKeys.monthStartInclusive(prevMonth),
                 RankingPeriodKeys.monthEndExclusive(prevMonth),
@@ -57,29 +49,5 @@ public class RankingSnapshotBatchService {
                 calculatedAt,
                 weekKey,
                 monthKey);
-    }
-
-    @Transactional
-    public void rebuildAllTime(Instant calculatedAt) {
-        jdbc.deleteStaging(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
-        jdbc.insertAllTimeStaging(calculatedAt);
-        jdbc.promoteStagingToMain(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
-        jdbc.deleteStagingAfterPromote(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
-    }
-
-    @Transactional
-    public void rebuildWeekly(String periodKey, Instant occurredStart, Instant occurredEndExclusive, Instant calculatedAt) {
-        jdbc.deleteStaging(RankingPeriodType.WEEKLY, periodKey);
-        jdbc.insertWeeklyStaging(occurredStart, occurredEndExclusive, periodKey, calculatedAt);
-        jdbc.promoteStagingToMain(RankingPeriodType.WEEKLY, periodKey);
-        jdbc.deleteStagingAfterPromote(RankingPeriodType.WEEKLY, periodKey);
-    }
-
-    @Transactional
-    public void rebuildMonthly(String periodKey, Instant occurredStart, Instant occurredEndExclusive, Instant calculatedAt) {
-        jdbc.deleteStaging(RankingPeriodType.MONTHLY, periodKey);
-        jdbc.insertMonthlyStaging(occurredStart, occurredEndExclusive, periodKey, calculatedAt);
-        jdbc.promoteStagingToMain(RankingPeriodType.MONTHLY, periodKey);
-        jdbc.deleteStagingAfterPromote(RankingPeriodType.MONTHLY, periodKey);
     }
 }

--- a/src/main/java/com/project/ranking/application/service/RankingSnapshotBatchService.java
+++ b/src/main/java/com/project/ranking/application/service/RankingSnapshotBatchService.java
@@ -1,0 +1,85 @@
+package com.project.ranking.application.service;
+
+import com.project.ranking.application.support.RankingPeriodKeys;
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.ranking.infrastructure.persistence.RankingSnapshotJdbcRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+/**
+ * 일 배치 — 스테이징 적재 → 본 테이블 프로모션. 동일 period 재실행 시 결과 대체.
+ * <p>
+ * {@link #runDailySnapshotBatch}는 단일 트랜잭션으로 전체·주·월 갱신을 묶어,
+ * 기간별 {@code promoteStagingToMain}(DELETE 후 INSERT … SELECT)가 중간에 끊기면
+ * 해당 period 본 테이블이 비는 상태가 되지 않도록 한다. 단건 {@code rebuild*} 호출도
+ * 각 메서드의 {@code @Transactional}으로 동일하게 한 트랜잭션에서 스테이징 정리까지 완료한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingSnapshotBatchService {
+
+    private final RankingSnapshotJdbcRepository jdbc;
+
+    /**
+     * 매일 실행: 전체·직전 완료 주·직전 완료 월 스냅샷을 갱신한다.
+     */
+    @Transactional
+    public void runDailySnapshotBatch(Instant calculatedAt) {
+        LocalDate today = RankingPeriodKeys.todaySeoul();
+        rebuildAllTime(calculatedAt);
+
+        LocalDate lastWeekMon = RankingPeriodKeys.lastCompletedWeekMonday(today);
+        String weekKey = RankingPeriodKeys.formatWeekKey(lastWeekMon);
+        rebuildWeekly(
+                weekKey,
+                RankingPeriodKeys.weekStartInclusive(lastWeekMon),
+                RankingPeriodKeys.weekEndExclusive(lastWeekMon),
+                calculatedAt);
+
+        YearMonth prevMonth = YearMonth.from(today).minusMonths(1);
+        String monthKey = prevMonth.toString();
+        rebuildMonthly(
+                monthKey,
+                RankingPeriodKeys.monthStartInclusive(prevMonth),
+                RankingPeriodKeys.monthEndExclusive(prevMonth),
+                calculatedAt);
+
+        log.info(
+                "랭킹 스냅샷 배치 완료 calculatedAt={} weeklyKey={} monthlyKey={}",
+                calculatedAt,
+                weekKey,
+                monthKey);
+    }
+
+    @Transactional
+    public void rebuildAllTime(Instant calculatedAt) {
+        jdbc.deleteStaging(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+        jdbc.insertAllTimeStaging(calculatedAt);
+        jdbc.promoteStagingToMain(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+        jdbc.deleteStagingAfterPromote(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+    }
+
+    @Transactional
+    public void rebuildWeekly(String periodKey, Instant occurredStart, Instant occurredEndExclusive, Instant calculatedAt) {
+        jdbc.deleteStaging(RankingPeriodType.WEEKLY, periodKey);
+        jdbc.insertWeeklyStaging(occurredStart, occurredEndExclusive, periodKey, calculatedAt);
+        jdbc.promoteStagingToMain(RankingPeriodType.WEEKLY, periodKey);
+        jdbc.deleteStagingAfterPromote(RankingPeriodType.WEEKLY, periodKey);
+    }
+
+    @Transactional
+    public void rebuildMonthly(String periodKey, Instant occurredStart, Instant occurredEndExclusive, Instant calculatedAt) {
+        jdbc.deleteStaging(RankingPeriodType.MONTHLY, periodKey);
+        jdbc.insertMonthlyStaging(occurredStart, occurredEndExclusive, periodKey, calculatedAt);
+        jdbc.promoteStagingToMain(RankingPeriodType.MONTHLY, periodKey);
+        jdbc.deleteStagingAfterPromote(RankingPeriodType.MONTHLY, periodKey);
+    }
+}

--- a/src/main/java/com/project/ranking/application/service/RankingSnapshotRebuildService.java
+++ b/src/main/java/com/project/ranking/application/service/RankingSnapshotRebuildService.java
@@ -1,0 +1,85 @@
+package com.project.ranking.application.service;
+
+import com.project.ranking.application.support.RankingPeriodKeys;
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.ranking.infrastructure.persistence.RankingBatchPeriodLock;
+import com.project.ranking.infrastructure.persistence.RankingSnapshotJdbcRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * 스냅샷 재구성의 트랜잭션 경계. 스테이징 적재 → 본 테이블 프로모션·정리를 기간 단위로 원자적으로 수행한다.
+ * <p>
+ * {@link RankingSnapshotBatchService}는 일일 순서·키 계산만 담당하고, 실제 작업은 이 클래스를 호출한다.
+ * PostgreSQL에서는 기간별 {@link RankingBatchPeriodLock}으로 동시 실행을 막는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingSnapshotRebuildService {
+
+    private final RankingSnapshotJdbcRepository jdbc;
+    private final RankingBatchPeriodLock periodLock;
+
+    @Transactional
+    public void rebuildAllTime(Instant calculatedAt) {
+        periodLock.acquire(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+        try {
+            jdbc.deleteStaging(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+            jdbc.insertAllTimeStaging(calculatedAt);
+            jdbc.promoteStagingToMain(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+            jdbc.deleteStagingAfterPromote(RankingPeriodType.ALL_TIME, RankingPeriodKeys.ALL_TIME_KEY);
+        } catch (RuntimeException e) {
+            log.error(
+                    "랭킹 스냅샷 배치 실패 periodType={} periodKey={} calculatedAt={}",
+                    RankingPeriodType.ALL_TIME,
+                    RankingPeriodKeys.ALL_TIME_KEY,
+                    calculatedAt,
+                    e);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void rebuildWeekly(String periodKey, Instant occurredStart, Instant occurredEndExclusive, Instant calculatedAt) {
+        periodLock.acquire(RankingPeriodType.WEEKLY, periodKey);
+        try {
+            jdbc.deleteStaging(RankingPeriodType.WEEKLY, periodKey);
+            jdbc.insertWeeklyStaging(occurredStart, occurredEndExclusive, periodKey, calculatedAt);
+            jdbc.promoteStagingToMain(RankingPeriodType.WEEKLY, periodKey);
+            jdbc.deleteStagingAfterPromote(RankingPeriodType.WEEKLY, periodKey);
+        } catch (RuntimeException e) {
+            log.error(
+                    "랭킹 스냅샷 배치 실패 periodType={} periodKey={} calculatedAt={}",
+                    RankingPeriodType.WEEKLY,
+                    periodKey,
+                    calculatedAt,
+                    e);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void rebuildMonthly(String periodKey, Instant occurredStart, Instant occurredEndExclusive, Instant calculatedAt) {
+        periodLock.acquire(RankingPeriodType.MONTHLY, periodKey);
+        try {
+            jdbc.deleteStaging(RankingPeriodType.MONTHLY, periodKey);
+            jdbc.insertMonthlyStaging(occurredStart, occurredEndExclusive, periodKey, calculatedAt);
+            jdbc.promoteStagingToMain(RankingPeriodType.MONTHLY, periodKey);
+            jdbc.deleteStagingAfterPromote(RankingPeriodType.MONTHLY, periodKey);
+        } catch (RuntimeException e) {
+            log.error(
+                    "랭킹 스냅샷 배치 실패 periodType={} periodKey={} calculatedAt={}",
+                    RankingPeriodType.MONTHLY,
+                    periodKey,
+                    calculatedAt,
+                    e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/project/ranking/application/support/RankingPeriodKeys.java
+++ b/src/main/java/com/project/ranking/application/support/RankingPeriodKeys.java
@@ -1,5 +1,6 @@
 package com.project.ranking.application.support;
 
+import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -48,16 +49,32 @@ public final class RankingPeriodKeys {
         return ym.format(MONTH_FMT);
     }
 
+    /**
+     * {@code YYYY-Www} ISO 주차 키를 검증하고 해당 주의 월요일을 반환한다.
+     * 주차 번호는 1~53이며, 파싱 후 {@link #formatWeekKey(LocalDate)}로 직렬화했을 때 입력과 동일해야 한다.
+     */
     public static LocalDate parseWeekMondayOrThrow(String periodKey) {
         if (!WEEK_KEY.matcher(periodKey).matches()) {
             throw new IllegalArgumentException("WEEKLY period_key은 YYYY-Www 형식이어야 합니다: " + periodKey);
         }
-        int y = Integer.parseInt(periodKey.substring(0, 4));
         int w = Integer.parseInt(periodKey.substring(6));
+        if (w < 1 || w > 53) {
+            throw new IllegalArgumentException("WEEKLY period_key의 주차는 1~53이어야 합니다: " + periodKey);
+        }
+        int y = Integer.parseInt(periodKey.substring(0, 4));
         LocalDate anchor = LocalDate.of(y, 1, 4);
-        return anchor
-                .with(ISO_WEEK.weekOfWeekBasedYear(), w)
-                .with(DayOfWeek.MONDAY);
+        LocalDate monday;
+        try {
+            monday = anchor.with(ISO_WEEK.weekOfWeekBasedYear(), w).with(DayOfWeek.MONDAY);
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException("유효하지 않은 ISO 주차입니다: " + periodKey, e);
+        }
+        String normalized = formatWeekKey(monday);
+        if (!periodKey.equals(normalized)) {
+            throw new IllegalArgumentException(
+                    "WEEKLY period_key가 정규 형식이 아닙니다. 입력=" + periodKey + ", 정규화=" + normalized);
+        }
+        return monday;
     }
 
     public static YearMonth parseYearMonthOrThrow(String periodKey) {

--- a/src/main/java/com/project/ranking/application/support/RankingPeriodKeys.java
+++ b/src/main/java/com/project/ranking/application/support/RankingPeriodKeys.java
@@ -1,0 +1,89 @@
+package com.project.ranking.application.support;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public final class RankingPeriodKeys {
+
+    public static final String ALL_TIME_KEY = "ALL";
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final WeekFields ISO_WEEK = WeekFields.of(DayOfWeek.MONDAY, 4);
+    private static final Pattern WEEK_KEY = Pattern.compile("^\\d{4}-W\\d{2}$");
+    private static final Pattern MONTH_KEY = Pattern.compile("^\\d{4}-\\d{2}$");
+    private static final DateTimeFormatter MONTH_FMT = DateTimeFormatter.ofPattern("uuuu-MM");
+
+    private RankingPeriodKeys() {
+    }
+
+    public static LocalDate todaySeoul() {
+        return LocalDate.now(SEOUL);
+    }
+
+    public static LocalDate lastCompletedWeekMonday(LocalDate todaySeoul) {
+        LocalDate thisWeekMonday = todaySeoul.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        return thisWeekMonday.minusWeeks(1);
+    }
+
+    public static String formatWeekKey(LocalDate weekMonday) {
+        int weekBasedYear = weekMonday.get(ISO_WEEK.weekBasedYear());
+        int week = weekMonday.get(ISO_WEEK.weekOfWeekBasedYear());
+        return String.format(Locale.ROOT, "%d-W%02d", weekBasedYear, week);
+    }
+
+    public static String defaultWeeklyPeriodKey(LocalDate todaySeoul) {
+        return formatWeekKey(lastCompletedWeekMonday(todaySeoul));
+    }
+
+    public static String defaultMonthlyPeriodKey(LocalDate todaySeoul) {
+        YearMonth ym = YearMonth.from(todaySeoul).minusMonths(1);
+        return ym.format(MONTH_FMT);
+    }
+
+    public static LocalDate parseWeekMondayOrThrow(String periodKey) {
+        if (!WEEK_KEY.matcher(periodKey).matches()) {
+            throw new IllegalArgumentException("WEEKLY period_key은 YYYY-Www 형식이어야 합니다: " + periodKey);
+        }
+        int y = Integer.parseInt(periodKey.substring(0, 4));
+        int w = Integer.parseInt(periodKey.substring(6));
+        LocalDate anchor = LocalDate.of(y, 1, 4);
+        return anchor
+                .with(ISO_WEEK.weekOfWeekBasedYear(), w)
+                .with(DayOfWeek.MONDAY);
+    }
+
+    public static YearMonth parseYearMonthOrThrow(String periodKey) {
+        if (!MONTH_KEY.matcher(periodKey).matches()) {
+            throw new IllegalArgumentException("MONTHLY period_key은 yyyy-MM 형식이어야 합니다: " + periodKey);
+        }
+        try {
+            return YearMonth.parse(periodKey, MONTH_FMT);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("MONTHLY period_key이 유효하지 않습니다: " + periodKey, e);
+        }
+    }
+
+    public static Instant weekStartInclusive(LocalDate weekMonday) {
+        return weekMonday.atStartOfDay(SEOUL).toInstant();
+    }
+
+    public static Instant weekEndExclusive(LocalDate weekMonday) {
+        return weekMonday.plusWeeks(1).atStartOfDay(SEOUL).toInstant();
+    }
+
+    public static Instant monthStartInclusive(YearMonth ym) {
+        return ym.atDay(1).atStartOfDay(SEOUL).toInstant();
+    }
+
+    public static Instant monthEndExclusive(YearMonth ym) {
+        return ym.plusMonths(1).atDay(1).atStartOfDay(SEOUL).toInstant();
+    }
+}

--- a/src/main/java/com/project/ranking/config/RankingConfiguration.java
+++ b/src/main/java/com/project/ranking/config/RankingConfiguration.java
@@ -1,0 +1,9 @@
+package com.project.ranking.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RankingProperties.class)
+public class RankingConfiguration {
+}

--- a/src/main/java/com/project/ranking/config/RankingProperties.java
+++ b/src/main/java/com/project/ranking/config/RankingProperties.java
@@ -1,0 +1,18 @@
+package com.project.ranking.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "ranking")
+public class RankingProperties {
+
+    private int maxPageSize = 100;
+
+    private int defaultPageSize = 20;
+
+    private boolean useWindowRankSql = true;
+}

--- a/src/main/java/com/project/ranking/config/RankingProperties.java
+++ b/src/main/java/com/project/ranking/config/RankingProperties.java
@@ -1,18 +1,30 @@
 package com.project.ranking.config;
 
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Validated
 @ConfigurationProperties(prefix = "ranking")
 public class RankingProperties {
 
+    @Min(1)
     private int maxPageSize = 100;
 
+    @Min(1)
     private int defaultPageSize = 20;
 
     private boolean useWindowRankSql = true;
+
+    @AssertTrue(message = "ranking.default-page-size는 ranking.max-page-size 이하여야 합니다.")
+    public boolean isConsistentPageSizes() {
+        return defaultPageSize <= maxPageSize;
+    }
 }

--- a/src/main/java/com/project/ranking/domain/RankingPeriodType.java
+++ b/src/main/java/com/project/ranking/domain/RankingPeriodType.java
@@ -1,0 +1,7 @@
+package com.project.ranking.domain;
+
+public enum RankingPeriodType {
+    ALL_TIME,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/com/project/ranking/domain/entity/RankingSnapshot.java
+++ b/src/main/java/com/project/ranking/domain/entity/RankingSnapshot.java
@@ -1,0 +1,57 @@
+package com.project.ranking.domain.entity;
+
+import com.project.global.entity.BaseEntity;
+import com.project.ranking.domain.RankingPeriodType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+/**
+ * 랭킹 스냅샷 본 테이블. 배치가 기록한 점수·순위(동점은 표준 SQL {@code RANK}와 동일)를 보관한다.
+ */
+@Entity
+@Table(
+        name = "ranking_snapshot",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_ranking_snapshot_period_user",
+                columnNames = {"period_type", "period_key", "user_id"}
+        )
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingSnapshot extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period_type", nullable = false, length = 20)
+    private RankingPeriodType periodType;
+
+    @Column(name = "period_key", nullable = false, length = 32)
+    private String periodKey;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "score", nullable = false)
+    private long score;
+
+    /**
+     * 배치 시점 순위: {@code RANK() OVER (ORDER BY score DESC)} (동점 동순위, 표준 RANK 간격).
+     */
+    @Column(name = "snapshot_rank", nullable = false)
+    private int snapshotRank;
+
+    @Column(name = "calculated_at", nullable = false, columnDefinition = "TIMESTAMPTZ")
+    private Instant calculatedAt;
+}

--- a/src/main/java/com/project/ranking/domain/entity/RankingSnapshotStaging.java
+++ b/src/main/java/com/project/ranking/domain/entity/RankingSnapshotStaging.java
@@ -1,0 +1,54 @@
+package com.project.ranking.domain.entity;
+
+import com.project.global.entity.BaseEntity;
+import com.project.ranking.domain.RankingPeriodType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+/**
+ * 스테이징 테이블 — 배치 적재 후 본 테이블로 프로모션하고 비운다.
+ */
+@Entity
+@Table(
+        name = "ranking_snapshot_staging",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_ranking_staging_period_user",
+                columnNames = {"period_type", "period_key", "user_id"}
+        )
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RankingSnapshotStaging extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period_type", nullable = false, length = 20)
+    private RankingPeriodType periodType;
+
+    @Column(name = "period_key", nullable = false, length = 32)
+    private String periodKey;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "score", nullable = false)
+    private long score;
+
+    @Column(name = "snapshot_rank", nullable = false)
+    private int snapshotRank;
+
+    @Column(name = "calculated_at", nullable = false, columnDefinition = "TIMESTAMPTZ")
+    private Instant calculatedAt;
+}

--- a/src/main/java/com/project/ranking/domain/repository/RankingSnapshotRepository.java
+++ b/src/main/java/com/project/ranking/domain/repository/RankingSnapshotRepository.java
@@ -1,0 +1,24 @@
+package com.project.ranking.domain.repository;
+
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.ranking.domain.entity.RankingSnapshot;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface RankingSnapshotRepository extends JpaRepository<RankingSnapshot, Long> {
+
+    @Modifying
+    @Query("DELETE FROM RankingSnapshot r WHERE r.periodType = :periodType AND r.periodKey = :periodKey")
+    int deleteByPeriod(@Param("periodType") RankingPeriodType periodType, @Param("periodKey") String periodKey);
+
+    @Query("SELECT MAX(r.calculatedAt) FROM RankingSnapshot r WHERE r.periodType = :periodType AND r.periodKey = :periodKey")
+    Optional<Instant> findMaxCalculatedAt(
+            @Param("periodType") RankingPeriodType periodType,
+            @Param("periodKey") String periodKey);
+}

--- a/src/main/java/com/project/ranking/domain/repository/RankingSnapshotStagingRepository.java
+++ b/src/main/java/com/project/ranking/domain/repository/RankingSnapshotStagingRepository.java
@@ -1,0 +1,16 @@
+package com.project.ranking.domain.repository;
+
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.ranking.domain.entity.RankingSnapshotStaging;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RankingSnapshotStagingRepository extends JpaRepository<RankingSnapshotStaging, Long> {
+
+    @Modifying
+    @Query("DELETE FROM RankingSnapshotStaging s WHERE s.periodType = :periodType AND s.periodKey = :periodKey")
+    int deleteByPeriod(@Param("periodType") RankingPeriodType periodType, @Param("periodKey") String periodKey);
+}

--- a/src/main/java/com/project/ranking/infrastructure/persistence/RankingBatchPeriodLock.java
+++ b/src/main/java/com/project/ranking/infrastructure/persistence/RankingBatchPeriodLock.java
@@ -1,0 +1,70 @@
+package com.project.ranking.infrastructure.persistence;
+
+import com.project.ranking.domain.RankingPeriodType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * 동일 {@code (period_type, period_key)} 배치가 분산 환경에서 동시에 돌지 않도록
+ * PostgreSQL {@code pg_advisory_xact_lock}으로 트랜잭션 범위 락을 잡는다.
+ * <p>
+ * H2 등 PostgreSQL이 아닌 경우는 no-op(테스트 단일 JVM).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingBatchPeriodLock {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final DataSource dataSource;
+
+    private volatile Boolean postgres;
+
+    /**
+     * 현재 트랜잭션에 묶인 advisory lock. 커밋/롤백 시 자동 해제.
+     */
+    public void acquire(RankingPeriodType periodType, String periodKey) {
+        if (!isPostgreSql()) {
+            return;
+        }
+        String k1 = periodType.name() + ":" + periodKey + "|a";
+        String k2 = periodType.name() + ":" + periodKey + "|b";
+        namedParameterJdbcTemplate.getJdbcTemplate().execute((ConnectionCallback<Void>) con -> {
+            try (PreparedStatement ps = con.prepareStatement(
+                    "SELECT pg_advisory_xact_lock(hashtext(?::text), hashtext(?::text))")) {
+                ps.setString(1, k1);
+                ps.setString(2, k2);
+                ps.execute();
+            }
+            return null;
+        });
+    }
+
+    private boolean isPostgreSql() {
+        Boolean cached = postgres;
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (this) {
+            if (postgres != null) {
+                return postgres;
+            }
+            try (Connection c = dataSource.getConnection()) {
+                postgres = "PostgreSQL".equalsIgnoreCase(c.getMetaData().getDatabaseProductName());
+            } catch (SQLException e) {
+                log.warn("DB 제품명 확인 실패 — 랭킹 배치 advisory lock 비활성: {}", e.getMessage());
+                postgres = false;
+            }
+            return postgres;
+        }
+    }
+}

--- a/src/main/java/com/project/ranking/infrastructure/persistence/RankingSnapshotJdbcRepository.java
+++ b/src/main/java/com/project/ranking/infrastructure/persistence/RankingSnapshotJdbcRepository.java
@@ -13,7 +13,9 @@ import java.time.Instant;
 /**
  * 배치용 네이티브 SQL — 집계 후 순위 부여·스테이징→본 테이블 프로모션.
  * <p>
- * 운영(PostgreSQL)은 {@code RANK() OVER (ORDER BY score DESC, user_id ASC)}(설정 기본).
+ * 트랜잭션 경계는 호출하는 {@link com.project.ranking.application.service.RankingSnapshotRebuildService}에서 잡는다.
+ * <p>
+ * 운영(PostgreSQL)은 {@code RANK() OVER (ORDER BY score DESC)}(설정 기본).
  * H2 통합 테스트는 {@link RankingProperties#isUseWindowRankSql()} 가 false일 때 동점에 표준 {@code RANK}와 동일한 식을 쓴다.
  */
 @Repository
@@ -78,7 +80,7 @@ public class RankingSnapshotJdbcRepository {
 
     /**
      * 본 테이블에서 해당 기간 행을 삭제한 뒤 스테이징에서 복사한다.
-     * 호출부({@code RankingSnapshotBatchService}의 {@code @Transactional})와 같은 트랜잭션에서 실행되어야 한다.
+     * 호출부({@code RankingSnapshotRebuildService}의 {@code @Transactional})와 같은 트랜잭션에서 실행되어야 한다.
      */
     public void promoteStagingToMain(RankingPeriodType periodType, String periodKey) {
         MapSqlParameterSource p = new MapSqlParameterSource()

--- a/src/main/java/com/project/ranking/infrastructure/persistence/RankingSnapshotJdbcRepository.java
+++ b/src/main/java/com/project/ranking/infrastructure/persistence/RankingSnapshotJdbcRepository.java
@@ -1,0 +1,188 @@
+package com.project.ranking.infrastructure.persistence;
+
+import com.project.ranking.config.RankingProperties;
+import com.project.ranking.domain.RankingPeriodType;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+/**
+ * 배치용 네이티브 SQL — 집계 후 순위 부여·스테이징→본 테이블 프로모션.
+ * <p>
+ * 운영(PostgreSQL)은 {@code RANK() OVER (ORDER BY score DESC, user_id ASC)}(설정 기본).
+ * H2 통합 테스트는 {@link RankingProperties#isUseWindowRankSql()} 가 false일 때 동점에 표준 {@code RANK}와 동일한 식을 쓴다.
+ */
+@Repository
+public class RankingSnapshotJdbcRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+    private final String insertAllTimeStagingSql;
+    private final String insertWeeklyStagingSql;
+    private final String insertMonthlyStagingSql;
+
+    public RankingSnapshotJdbcRepository(
+            NamedParameterJdbcTemplate jdbc,
+            RankingProperties rankingProperties) {
+        this.jdbc = jdbc;
+        this.insertAllTimeStagingSql = buildInsertAllTimeStagingSql(rankingProperties);
+        this.insertWeeklyStagingSql = buildInsertWeeklyStagingSql(rankingProperties);
+        this.insertMonthlyStagingSql = buildInsertMonthlyStagingSql(rankingProperties);
+    }
+
+    public void deleteStaging(RankingPeriodType periodType, String periodKey) {
+        jdbc.update(
+                """
+                DELETE FROM ranking_snapshot_staging
+                WHERE period_type = :periodType AND period_key = :periodKey
+                """,
+                new MapSqlParameterSource()
+                        .addValue("periodType", periodType.name())
+                        .addValue("periodKey", periodKey));
+    }
+
+    public void insertAllTimeStaging(Instant calculatedAt) {
+        MapSqlParameterSource p = new MapSqlParameterSource()
+                .addValue("calculatedAt", Timestamp.from(calculatedAt));
+        jdbc.update(insertAllTimeStagingSql, p);
+    }
+
+    public void insertWeeklyStaging(
+            Instant occurredAtStartInclusive,
+            Instant occurredAtEndExclusive,
+            String periodKey,
+            Instant calculatedAt) {
+        MapSqlParameterSource p = new MapSqlParameterSource()
+                .addValue("start", Timestamp.from(occurredAtStartInclusive))
+                .addValue("endEx", Timestamp.from(occurredAtEndExclusive))
+                .addValue("periodKey", periodKey)
+                .addValue("calculatedAt", Timestamp.from(calculatedAt));
+        jdbc.update(insertWeeklyStagingSql, p);
+    }
+
+    public void insertMonthlyStaging(
+            Instant occurredAtStartInclusive,
+            Instant occurredAtEndExclusive,
+            String periodKey,
+            Instant calculatedAt) {
+        MapSqlParameterSource p = new MapSqlParameterSource()
+                .addValue("start", Timestamp.from(occurredAtStartInclusive))
+                .addValue("endEx", Timestamp.from(occurredAtEndExclusive))
+                .addValue("periodKey", periodKey)
+                .addValue("calculatedAt", Timestamp.from(calculatedAt));
+        jdbc.update(insertMonthlyStagingSql, p);
+    }
+
+    /**
+     * 본 테이블에서 해당 기간 행을 삭제한 뒤 스테이징에서 복사한다.
+     * 호출부({@code RankingSnapshotBatchService}의 {@code @Transactional})와 같은 트랜잭션에서 실행되어야 한다.
+     */
+    public void promoteStagingToMain(RankingPeriodType periodType, String periodKey) {
+        MapSqlParameterSource p = new MapSqlParameterSource()
+                .addValue("periodType", periodType.name())
+                .addValue("periodKey", periodKey);
+        jdbc.update(
+                """
+                DELETE FROM ranking_snapshot
+                WHERE period_type = :periodType AND period_key = :periodKey
+                """,
+                p);
+        jdbc.update(
+                """
+                INSERT INTO ranking_snapshot
+                    (period_type, period_key, user_id, score, snapshot_rank, calculated_at)
+                SELECT period_type, period_key, user_id, score, snapshot_rank, calculated_at
+                FROM ranking_snapshot_staging
+                WHERE period_type = :periodType AND period_key = :periodKey
+                """,
+                p);
+    }
+
+    public void deleteStagingAfterPromote(RankingPeriodType periodType, String periodKey) {
+        deleteStaging(periodType, periodKey);
+    }
+
+    private static String buildInsertAllTimeStagingSql(RankingProperties p) {
+        String rankExpr = p.isUseWindowRankSql()
+                ? "RANK() OVER (ORDER BY u.total_point DESC)"
+                : "1 + (SELECT COUNT(*) FROM users u2 WHERE u2.deleted_at IS NULL AND u2.total_point > u.total_point)";
+        return """
+                INSERT INTO ranking_snapshot_staging
+                    (period_type, period_key, user_id, score, snapshot_rank, calculated_at)
+                SELECT
+                    'ALL_TIME', 'ALL', u.user_id, u.total_point,
+                    """
+                + rankExpr
+                + """
+                ,
+                    :calculatedAt
+                FROM users u
+                WHERE u.deleted_at IS NULL
+                """;
+    }
+
+    private static String buildInsertWeeklyStagingSql(RankingProperties p) {
+        String rankExpr = p.isUseWindowRankSql()
+                ? "RANK() OVER (ORDER BY agg.period_score DESC)"
+                : """
+                1 + (SELECT COUNT(*) FROM (
+                        SELECT uc2.user_id AS uid, SUM(uc2.signed_point) AS ps
+                        FROM user_contribution uc2
+                        INNER JOIN users u2 ON u2.user_id = uc2.user_id AND u2.deleted_at IS NULL
+                        WHERE uc2.occurred_at >= :start AND uc2.occurred_at < :endEx
+                        GROUP BY uc2.user_id
+                    ) x WHERE x.ps > agg.period_score)""";
+        return """
+                INSERT INTO ranking_snapshot_staging
+                    (period_type, period_key, user_id, score, snapshot_rank, calculated_at)
+                SELECT
+                    'WEEKLY', :periodKey, agg.user_id, agg.period_score,
+                    """
+                + rankExpr
+                + """
+                ,
+                    :calculatedAt
+                FROM (
+                    SELECT uc.user_id AS user_id, SUM(uc.signed_point) AS period_score
+                    FROM user_contribution uc
+                    INNER JOIN users u ON u.user_id = uc.user_id AND u.deleted_at IS NULL
+                    WHERE uc.occurred_at >= :start AND uc.occurred_at < :endEx
+                    GROUP BY uc.user_id
+                ) agg
+                """;
+    }
+
+    private static String buildInsertMonthlyStagingSql(RankingProperties p) {
+        String rankExpr = p.isUseWindowRankSql()
+                ? "RANK() OVER (ORDER BY agg.period_score DESC)"
+                : """
+                1 + (SELECT COUNT(*) FROM (
+                        SELECT uc2.user_id AS uid, SUM(uc2.signed_point) AS ps
+                        FROM user_contribution uc2
+                        INNER JOIN users u2 ON u2.user_id = uc2.user_id AND u2.deleted_at IS NULL
+                        WHERE uc2.occurred_at >= :start AND uc2.occurred_at < :endEx
+                        GROUP BY uc2.user_id
+                    ) x WHERE x.ps > agg.period_score)""";
+        return """
+                INSERT INTO ranking_snapshot_staging
+                    (period_type, period_key, user_id, score, snapshot_rank, calculated_at)
+                SELECT
+                    'MONTHLY', :periodKey, agg.user_id, agg.period_score,
+                    """
+                + rankExpr
+                + """
+                ,
+                    :calculatedAt
+                FROM (
+                    SELECT uc.user_id AS user_id, SUM(uc.signed_point) AS period_score
+                    FROM user_contribution uc
+                    INNER JOIN users u ON u.user_id = uc.user_id AND u.deleted_at IS NULL
+                    WHERE uc.occurred_at >= :start AND uc.occurred_at < :endEx
+                    GROUP BY uc.user_id
+                ) agg
+                """;
+    }
+}

--- a/src/main/java/com/project/ranking/presentation/controller/RankingController.java
+++ b/src/main/java/com/project/ranking/presentation/controller/RankingController.java
@@ -1,0 +1,64 @@
+package com.project.ranking.presentation.controller;
+
+import com.project.global.error.BusinessException;
+import com.project.global.error.ErrorCode;
+import com.project.global.response.CommonResponse;
+import com.project.ranking.application.dto.RankingListResponse;
+import com.project.ranking.application.dto.RankingMeResponse;
+import com.project.ranking.application.service.RankingQueryService;
+import com.project.ranking.config.RankingProperties;
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.ranking.presentation.swagger.RankingControllerDocs;
+import com.project.user.application.dto.UserSession;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rankings")
+@RequiredArgsConstructor
+public class RankingController implements RankingControllerDocs {
+
+    private final RankingQueryService rankingQueryService;
+    private final RankingProperties rankingProperties;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<CommonResponse<RankingListResponse>> list(
+            @RequestParam("period_type") RankingPeriodType periodType,
+            @RequestParam(value = "period_key", required = false) String periodKey,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", required = false) Integer size,
+            @Parameter(hidden = true) HttpSession session) {
+        int pageSize = size != null ? size : rankingProperties.getDefaultPageSize();
+        Long me = extractUserId(session);
+        RankingListResponse body = rankingQueryService.list(periodType, periodKey, page, pageSize, me);
+        return ResponseEntity.ok(CommonResponse.ok(body));
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<CommonResponse<RankingMeResponse>> myRank(
+            @RequestParam("period_type") RankingPeriodType periodType,
+            @RequestParam(value = "period_key", required = false) String periodKey,
+            @Parameter(hidden = true) HttpSession session) {
+        UserSession user = (UserSession) session.getAttribute("LOGIN_USER");
+        if (user == null) {
+            throw new BusinessException(ErrorCode.SESSION_NOT_FOUND);
+        }
+        RankingMeResponse body = rankingQueryService.myRank(periodType, periodKey, user.getUserId());
+        return ResponseEntity.ok(CommonResponse.ok(body));
+    }
+
+    private static Long extractUserId(HttpSession session) {
+        UserSession user = (UserSession) session.getAttribute("LOGIN_USER");
+        return user != null ? user.getUserId() : null;
+    }
+}

--- a/src/main/java/com/project/ranking/presentation/swagger/RankingControllerDocs.java
+++ b/src/main/java/com/project/ranking/presentation/swagger/RankingControllerDocs.java
@@ -1,0 +1,50 @@
+package com.project.ranking.presentation.swagger;
+
+import com.project.global.response.CommonResponse;
+import com.project.ranking.application.dto.RankingListResponse;
+import com.project.ranking.application.dto.RankingMeResponse;
+import com.project.ranking.domain.RankingPeriodType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Ranking", description = "랭킹 스냅샷 조회 API")
+public interface RankingControllerDocs {
+
+    @Operation(
+            summary = "랭킹 스냅샷 목록 조회",
+            description = "페이징된 랭킹 목록과 집계 메타를 반환합니다. period_key를 생략하면 ALL_TIME은 ALL, 주간·월간은 직전 완료 기간을 적용합니다. "
+                    + "스냅샷이 없으면 빈 목록을 반환합니다. 로그인 시 본인 행에 isMe를 표시합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    ResponseEntity<CommonResponse<RankingListResponse>> list(
+            @Parameter(description = "집계 기간 유형", required = true, example = "WEEKLY")
+            @RequestParam("period_type") RankingPeriodType periodType,
+            @Parameter(description = "기간 키 · 생략 시 서버 기본")
+            @RequestParam(value = "period_key", required = false) String periodKey,
+            @Parameter(description = "페이지 번호(0부터)", example = "0")
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기 · 생략 시 기본값")
+            @RequestParam(value = "size", required = false) Integer size,
+            @Parameter(hidden = true) HttpSession session);
+
+    @Operation(
+            summary = "내 랭킹 조회",
+            description = "로그인 사용자의 해당 기간 랭킹을 반환합니다. 스냅샷이 없거나 포함되지 않으면 404를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "401", description = "세션 만료", content = @Content(schema = @Schema(hidden = true)))
+    @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    ResponseEntity<CommonResponse<RankingMeResponse>> myRank(
+            @Parameter(description = "집계 기간 유형", required = true, example = "MONTHLY")
+            @RequestParam("period_type") RankingPeriodType periodType,
+            @Parameter(description = "기간 키 · 목록 조회와 동일(생략 시 서버 기본)")
+            @RequestParam(value = "period_key", required = false) String periodKey,
+            @Parameter(hidden = true) HttpSession session);
+}

--- a/src/main/java/com/project/ranking/scheduler/RankingBatchScheduler.java
+++ b/src/main/java/com/project/ranking/scheduler/RankingBatchScheduler.java
@@ -21,10 +21,14 @@ public class RankingBatchScheduler {
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     public void runDailyRankingBatch() {
+        Instant calculatedAt = Instant.now();
         try {
-            rankingSnapshotBatchService.runDailySnapshotBatch(Instant.now());
+            rankingSnapshotBatchService.runDailySnapshotBatch(calculatedAt);
         } catch (Exception e) {
-            log.error("랭킹 스냅샷 배치 실패", e);
+            log.error(
+                    "랭킹 스냅샷 배치(일일) 실패 calculatedAt={} — 상세는 기간별 로그 또는 스택트레이스 참고",
+                    calculatedAt,
+                    e);
         }
     }
 }

--- a/src/main/java/com/project/ranking/scheduler/RankingBatchScheduler.java
+++ b/src/main/java/com/project/ranking/scheduler/RankingBatchScheduler.java
@@ -1,0 +1,30 @@
+package com.project.ranking.scheduler;
+
+import com.project.ranking.application.service.RankingSnapshotBatchService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/**
+ * 매일 03:00 KST에 랭킹 스냅샷 배치를 실행한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingBatchScheduler {
+
+    private final RankingSnapshotBatchService rankingSnapshotBatchService;
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void runDailyRankingBatch() {
+        try {
+            rankingSnapshotBatchService.runDailySnapshotBatch(Instant.now());
+        } catch (Exception e) {
+            log.error("랭킹 스냅샷 배치 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/project/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/project/user/domain/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -42,6 +43,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "SELECT 1 FROM u.socialAccounts s WHERE s.provider = :provider AND s.providerId = :providerId) AND u.deletedAt IS NULL")
     Optional<User> findByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
 
+    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE User u SET u.totalPoint = u.totalPoint + :delta WHERE u.id = :userId AND u.deletedAt IS NULL "
             + "AND (u.totalPoint + :delta) >= 0")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,11 @@ spring:
     redis:
       namespace: "{hufsdev:session}"
 
+ranking:
+  max-page-size: 100
+  default-page-size: 20
+  use-window-rank-sql: true
+
 contribution:
   outbox:
     poll-interval-ms: 500

--- a/src/test/java/com/project/ranking/application/service/RankingQueryServiceIntegrationTest.java
+++ b/src/test/java/com/project/ranking/application/service/RankingQueryServiceIntegrationTest.java
@@ -38,7 +38,7 @@ class RankingQueryServiceIntegrationTest {
     private ContributionOutboxStaleReclaimer contributionOutboxStaleReclaimer;
 
     @Autowired
-    private RankingSnapshotBatchService batchService;
+    private RankingSnapshotRebuildService snapshotRebuildService;
 
     @Autowired
     private RankingQueryService rankingQueryService;
@@ -68,7 +68,7 @@ class RankingQueryServiceIntegrationTest {
         User active = persistUser(badge, 10);
         User withdrawn = persistUser(badge, 20);
 
-        batchService.rebuildAllTime(Instant.now());
+        snapshotRebuildService.rebuildAllTime(Instant.now());
 
         RankingListResponse before = rankingQueryService.list(RankingPeriodType.ALL_TIME, "ALL", 0, 10, null);
         assertThat(before.page().totalElements()).isEqualTo(2L);
@@ -91,7 +91,7 @@ class RankingQueryServiceIntegrationTest {
         persistUser(badge, 100);
         persistUser(badge, 100);
 
-        batchService.rebuildAllTime(Instant.now());
+        snapshotRebuildService.rebuildAllTime(Instant.now());
 
         RankingListResponse res = rankingQueryService.list(RankingPeriodType.ALL_TIME, "ALL", 0, 10, null);
         assertThat(res.content().get(0).displayRank()).isEqualTo(1);

--- a/src/test/java/com/project/ranking/application/service/RankingQueryServiceIntegrationTest.java
+++ b/src/test/java/com/project/ranking/application/service/RankingQueryServiceIntegrationTest.java
@@ -1,0 +1,112 @@
+package com.project.ranking.application.service;
+
+import com.project.contribution.worker.ContributionOutboxStaleReclaimer;
+import com.project.contribution.worker.ContributionOutboxWorker;
+import com.project.ranking.application.dto.RankingListResponse;
+import com.project.ranking.domain.RankingPeriodType;
+import com.project.user.domain.entity.LevelBadge;
+import com.project.user.domain.entity.User;
+import com.project.user.domain.repository.LevelBadgeRepository;
+import com.project.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RankingQueryServiceIntegrationTest {
+
+    @MockitoBean
+    private JavaMailSender javaMailSender;
+
+    @MockitoBean
+    private ContributionOutboxWorker contributionOutboxWorker;
+
+    @MockitoBean
+    private ContributionOutboxStaleReclaimer contributionOutboxStaleReclaimer;
+
+    @Autowired
+    private RankingSnapshotBatchService batchService;
+
+    @Autowired
+    private RankingQueryService rankingQueryService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LevelBadgeRepository levelBadgeRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void clean() {
+        jdbcTemplate.update("DELETE FROM ranking_snapshot");
+        jdbcTemplate.update("DELETE FROM ranking_snapshot_staging");
+        jdbcTemplate.update("DELETE FROM user_contribution");
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("탈퇴 유저는 스냅샷에 남아 있어도 목록·COUNT에서 제외되고 displayRank가 재계산된다")
+    void deletedUsersExcludedFromDisplayRankAndCount() {
+        LevelBadge badge = levelBadgeRepository.findByPointWithinRange(0).orElseThrow();
+        User active = persistUser(badge, 10);
+        User withdrawn = persistUser(badge, 20);
+
+        batchService.rebuildAllTime(Instant.now());
+
+        RankingListResponse before = rankingQueryService.list(RankingPeriodType.ALL_TIME, "ALL", 0, 10, null);
+        assertThat(before.page().totalElements()).isEqualTo(2L);
+        assertThat(before.content().getFirst().displayRank()).isEqualTo(1);
+
+        withdrawn.withdraw();
+        userRepository.saveAndFlush(withdrawn);
+
+        RankingListResponse after = rankingQueryService.list(RankingPeriodType.ALL_TIME, "ALL", 0, 10, null);
+        assertThat(after.page().totalElements()).isEqualTo(1L);
+        assertThat(after.content()).hasSize(1);
+        assertThat(after.content().getFirst().displayRank()).isEqualTo(1);
+        assertThat(after.content().getFirst().userId()).isEqualTo(active.getId());
+    }
+
+    @Test
+    @DisplayName("목록은 DB RANK 결과와 동일한 displayRank를 반환한다")
+    void displayRankMatchesRankInDatabase() {
+        LevelBadge badge = levelBadgeRepository.findByPointWithinRange(0).orElseThrow();
+        persistUser(badge, 100);
+        persistUser(badge, 100);
+
+        batchService.rebuildAllTime(Instant.now());
+
+        RankingListResponse res = rankingQueryService.list(RankingPeriodType.ALL_TIME, "ALL", 0, 10, null);
+        assertThat(res.content().get(0).displayRank()).isEqualTo(1);
+        assertThat(res.content().get(1).displayRank()).isEqualTo(1);
+    }
+
+    private User persistUser(LevelBadge badge, int totalPoint) {
+        User u = User.builder()
+                .email("q-" + UUID.randomUUID() + "@test.com")
+                .password("pw")
+                .nickname("n-" + UUID.randomUUID().toString().substring(0, 24))
+                .build();
+        u.initializeLevelBadge(badge);
+        User saved = userRepository.save(u);
+        jdbcTemplate.update("UPDATE users SET total_point = ? WHERE user_id = ?", totalPoint, saved.getId());
+        return userRepository.findById(saved.getId()).orElseThrow();
+    }
+}

--- a/src/test/java/com/project/ranking/application/service/RankingSnapshotBatchServiceIntegrationTest.java
+++ b/src/test/java/com/project/ranking/application/service/RankingSnapshotBatchServiceIntegrationTest.java
@@ -1,0 +1,163 @@
+package com.project.ranking.application.service;
+
+import com.project.contribution.worker.ContributionOutboxStaleReclaimer;
+import com.project.contribution.worker.ContributionOutboxWorker;
+import com.project.ranking.application.support.RankingPeriodKeys;
+import com.project.user.domain.entity.LevelBadge;
+import com.project.user.domain.entity.User;
+import com.project.user.domain.repository.LevelBadgeRepository;
+import com.project.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RankingSnapshotBatchServiceIntegrationTest {
+
+    @MockitoBean
+    private JavaMailSender javaMailSender;
+
+    @MockitoBean
+    private ContributionOutboxWorker contributionOutboxWorker;
+
+    @MockitoBean
+    private ContributionOutboxStaleReclaimer contributionOutboxStaleReclaimer;
+
+    @Autowired
+    private RankingSnapshotBatchService batchService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LevelBadgeRepository levelBadgeRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void clean() {
+        jdbcTemplate.update("DELETE FROM ranking_snapshot");
+        jdbcTemplate.update("DELETE FROM ranking_snapshot_staging");
+        jdbcTemplate.update("DELETE FROM user_contribution");
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("ALL_TIME 배치는 멱등이며 RANK 동점 처리(1,1,3)를 저장한다")
+    void allTimeBatchIsIdempotentAndUsesRank() {
+        LevelBadge badge = levelBadgeRepository.findByPointWithinRange(0).orElseThrow();
+        User u1 = persistUser(badge, 100);
+        User u2 = persistUser(badge, 100);
+        User u3 = persistUser(badge, 50);
+
+        Instant t = Instant.parse("2026-04-01T00:00:00Z");
+        batchService.rebuildAllTime(t);
+        batchService.rebuildAllTime(t);
+
+        List<Integer> ranks = jdbcTemplate.query(
+                """
+                SELECT snapshot_rank FROM ranking_snapshot
+                WHERE period_type = 'ALL_TIME' AND period_key = 'ALL'
+                ORDER BY user_id
+                """,
+                (rs, i) -> rs.getInt(1));
+        assertThat(ranks).containsExactly(1, 1, 3);
+    }
+
+    @Test
+    @DisplayName("동일 ALL_TIME period 재실행 후에도 행 수는 동일(멱등)")
+    void uniqueReplacePromotion() {
+        LevelBadge badge = levelBadgeRepository.findByPointWithinRange(0).orElseThrow();
+        persistUser(badge, 10);
+
+        Instant t = Instant.now();
+        batchService.rebuildAllTime(t);
+        long c = countAllTimeRows();
+        assertThat(c).isEqualTo(1L);
+
+        batchService.rebuildAllTime(t);
+        assertThat(countAllTimeRows()).isEqualTo(c);
+    }
+
+    @Test
+    @DisplayName("WEEKLY 스냅샷은 occurred_at 구간 합산만 반영한다")
+    void weeklySnapshotUsesOccurredAtWindow() {
+        LevelBadge badge = levelBadgeRepository.findByPointWithinRange(0).orElseThrow();
+        User u = persistUser(badge, 0);
+
+        LocalDate monday = LocalDate.of(2026, 3, 30);
+        String weekKey = RankingPeriodKeys.formatWeekKey(monday);
+        Instant start = RankingPeriodKeys.weekStartInclusive(monday);
+        Instant end = RankingPeriodKeys.weekEndExclusive(monday);
+
+        Long contributionScoreId = jdbcTemplate.queryForObject(
+                "SELECT cont_id FROM contribution_score WHERE cont_code = 'POST_WRITE' LIMIT 1",
+                Long.class);
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO user_contribution
+                (user_id, contribution_id, reference_id, entry_type, signed_point, occurred_at,
+                 idempotency_key, activity_type, reference_type, created_at, updated_at)
+                VALUES (?, ?, 1, 'GRANT', 5, ?, ?, 'POST_CREATED', 'POST', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                u.getId(),
+                contributionScoreId,
+                java.sql.Timestamp.from(start.plusSeconds(3600)),
+                "wk-" + UUID.randomUUID());
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO user_contribution
+                (user_id, contribution_id, reference_id, entry_type, signed_point, occurred_at,
+                 idempotency_key, activity_type, reference_type, created_at, updated_at)
+                VALUES (?, ?, 2, 'GRANT', 99, ?, ?, 'POST_CREATED', 'POST', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                u.getId(),
+                contributionScoreId,
+                java.sql.Timestamp.from(end.plusSeconds(1)),
+                "wk2-" + UUID.randomUUID());
+
+        batchService.rebuildWeekly(weekKey, start, end, Instant.now());
+
+        Long score = jdbcTemplate.queryForObject(
+                "SELECT score FROM ranking_snapshot WHERE period_type = 'WEEKLY' AND period_key = ? AND user_id = ?",
+                Long.class,
+                weekKey,
+                u.getId());
+        assertThat(score).isEqualTo(5L);
+    }
+
+    private long countAllTimeRows() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM ranking_snapshot WHERE period_type = 'ALL_TIME' AND period_key = 'ALL'",
+                Long.class);
+    }
+
+    private User persistUser(LevelBadge badge, int totalPoint) {
+        User u = User.builder()
+                .email("r-" + UUID.randomUUID() + "@test.com")
+                .password("pw")
+                .nickname("n-" + UUID.randomUUID().toString().substring(0, 24))
+                .build();
+        u.initializeLevelBadge(badge);
+        User saved = userRepository.save(u);
+        jdbcTemplate.update("UPDATE users SET total_point = ? WHERE user_id = ?", totalPoint, saved.getId());
+        return userRepository.findById(saved.getId()).orElseThrow();
+    }
+}

--- a/src/test/java/com/project/ranking/application/service/RankingSnapshotBatchServiceIntegrationTest.java
+++ b/src/test/java/com/project/ranking/application/service/RankingSnapshotBatchServiceIntegrationTest.java
@@ -38,7 +38,7 @@ class RankingSnapshotBatchServiceIntegrationTest {
     private ContributionOutboxStaleReclaimer contributionOutboxStaleReclaimer;
 
     @Autowired
-    private RankingSnapshotBatchService batchService;
+    private RankingSnapshotRebuildService snapshotRebuildService;
 
     @Autowired
     private UserRepository userRepository;
@@ -66,8 +66,8 @@ class RankingSnapshotBatchServiceIntegrationTest {
         User u3 = persistUser(badge, 50);
 
         Instant t = Instant.parse("2026-04-01T00:00:00Z");
-        batchService.rebuildAllTime(t);
-        batchService.rebuildAllTime(t);
+        snapshotRebuildService.rebuildAllTime(t);
+        snapshotRebuildService.rebuildAllTime(t);
 
         List<Integer> ranks = jdbcTemplate.query(
                 """
@@ -86,11 +86,11 @@ class RankingSnapshotBatchServiceIntegrationTest {
         persistUser(badge, 10);
 
         Instant t = Instant.now();
-        batchService.rebuildAllTime(t);
+        snapshotRebuildService.rebuildAllTime(t);
         long c = countAllTimeRows();
         assertThat(c).isEqualTo(1L);
 
-        batchService.rebuildAllTime(t);
+        snapshotRebuildService.rebuildAllTime(t);
         assertThat(countAllTimeRows()).isEqualTo(c);
     }
 
@@ -133,7 +133,7 @@ class RankingSnapshotBatchServiceIntegrationTest {
                 java.sql.Timestamp.from(end.plusSeconds(1)),
                 "wk2-" + UUID.randomUUID());
 
-        batchService.rebuildWeekly(weekKey, start, end, Instant.now());
+        snapshotRebuildService.rebuildWeekly(weekKey, start, end, Instant.now());
 
         Long score = jdbcTemplate.queryForObject(
                 "SELECT score FROM ranking_snapshot WHERE period_type = 'WEEKLY' AND period_key = ? AND user_id = ?",

--- a/src/test/java/com/project/ranking/application/support/RankingPeriodKeysTest.java
+++ b/src/test/java/com/project/ranking/application/support/RankingPeriodKeysTest.java
@@ -1,0 +1,41 @@
+package com.project.ranking.application.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RankingPeriodKeysTest {
+
+    @Test
+    @DisplayName("직전 완료 주 키는 ISO 주차 문자열이다")
+    void weekKeyFormat() {
+        LocalDate monday = LocalDate.of(2026, 3, 30);
+        assertThat(RankingPeriodKeys.formatWeekKey(monday)).matches("\\d{4}-W\\d{2}");
+    }
+
+    @Test
+    @DisplayName("주 키 파싱 후 월요일이 일치한다")
+    void weekKeyRoundTrip() {
+        LocalDate monday = LocalDate.of(2026, 4, 6);
+        String key = RankingPeriodKeys.formatWeekKey(monday);
+        assertThat(RankingPeriodKeys.parseWeekMondayOrThrow(key)).isEqualTo(monday);
+    }
+
+    @Test
+    @DisplayName("잘못된 WEEKLY 키는 예외")
+    void invalidWeekKey() {
+        assertThatThrownBy(() -> RankingPeriodKeys.parseWeekMondayOrThrow("2026-04"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("월 키 파싱")
+    void monthKey() {
+        assertThat(RankingPeriodKeys.parseYearMonthOrThrow("2026-03")).isEqualTo(YearMonth.of(2026, 3));
+    }
+}

--- a/src/test/java/com/project/ranking/application/support/RankingPeriodKeysTest.java
+++ b/src/test/java/com/project/ranking/application/support/RankingPeriodKeysTest.java
@@ -34,6 +34,23 @@ class RankingPeriodKeysTest {
     }
 
     @Test
+    @DisplayName("주차 0 또는 54 이상은 예외")
+    void weekNumberOutOfRange() {
+        assertThatThrownBy(() -> RankingPeriodKeys.parseWeekMondayOrThrow("2026-W00"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> RankingPeriodKeys.parseWeekMondayOrThrow("2026-W54"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("ISO 주차와 week-based year가 어긋나면 round-trip 실패(예: 1995-W53 → 1996-W01)")
+    void weekKeyMustMatchNormalizedForm() {
+        assertThatThrownBy(() -> RankingPeriodKeys.parseWeekMondayOrThrow("1995-W53"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정규 형식");
+    }
+
+    @Test
     @DisplayName("월 키 파싱")
     void monthKey() {
         assertThat(RankingPeriodKeys.parseYearMonthOrThrow("2026-03")).isEqualTo(YearMonth.of(2026, 3));

--- a/src/test/java/com/project/user/domain/repository/UserRepositoryConcurrentTotalPointTest.java
+++ b/src/test/java/com/project/user/domain/repository/UserRepositoryConcurrentTotalPointTest.java
@@ -1,0 +1,71 @@
+package com.project.user.domain.repository;
+
+import com.project.user.domain.entity.LevelBadge;
+import com.project.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class UserRepositoryConcurrentTotalPointTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LevelBadgeRepository levelBadgeRepository;
+
+    @Test
+    @DisplayName("동시 addTotalPoints 호출 시 총점 유실이 없어야 한다")
+    void concurrentAtomicAdds() throws Exception {
+        LevelBadge badge = levelBadgeRepository.findByPointWithinRange(0).orElseThrow();
+        User u = User.builder()
+                .email("conc-" + UUID.randomUUID() + "@test.com")
+                .password("pw")
+                .nickname("c-" + UUID.randomUUID().toString().substring(0, 24))
+                .build();
+        u.initializeLevelBadge(badge);
+        Long userId = userRepository.saveAndFlush(u).getId();
+
+        int threads = 20;
+        int deltaEach = 3;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                start.await();
+                int updated = userRepository.addTotalPoints(userId, deltaEach);
+                if (updated != 1) {
+                    throw new IllegalStateException("update not applied");
+                }
+                return null;
+            }));
+        }
+        start.countDown();
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        pool.shutdown();
+
+        try {
+            User reloaded = userRepository.findById(userId).orElseThrow();
+            assertThat(reloaded.getTotalPoint()).isEqualTo(threads * deltaEach);
+        } finally {
+            userRepository.deleteById(userId);
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,6 +16,9 @@ contribution:
   outbox:
     use-skip-locked: false
 
+ranking:
+  use-window-rank-sql: false
+
 cors:
   allowed-origins:
     - http://localhost:5173


### PR DESCRIPTION
## 📌 관련 이슈
- closes #79 

## ✨ 작업 내용
- 일 배치로 집계하는 랭킹 스냅샷(전체·주간·월간)과 조회 API(GET /api/v1/rankings, /me)를 추가하고, 동점·표시 순위·문서·테스트를 설계와 맞게 정리했습니다.이번 PR에서 수행한 작업을 간단히 요약해주세요.

## 🔍 주요 변경 사항

- com.project.ranking: 스테이징 → 본 테이블 프로모션 배치(RankingSnapshotBatchService, RankingSnapshotJdbcRepository), 매일 03:00 KST 스케줄, RankingQueryService로 목록·내 순위·메타(RankingMetaFactory, RankingPeriodKeys)
- 순위 규칙: RANK() OVER (ORDER BY score DESC)만 사용하고, 동점 내 목록 정렬은 display_rank, user_id로 분리(배치·조회·문서 정합)
- 보안: GET /api/v1/rankings 비로그인 허용, /me는 세션 필요(기존 패턴과 동일)
- Swagger: RankingControllerDocs에 태그·요약·파라미터·응답 코드 정리
- 문서: TECHNICAL_DESIGN_CONTRIBUTION_BADGE_RANKING.md, contribution-implementation-guide.md에 displayRank·RANK·ALL_TIME vs 기간 집계 등 반영
- 테스트: 랭킹 배치·조회 통합 테스트, RankingPeriodKeys 단위 테스트, UserRepository 동시성 총점 갱신 테스트 등
- 설정: application.yml / application-test.yml에 ranking.* 등 필요한 설정 추가

## 🧪 테스트 여부
- [x] 로컬 테스트 완료
- [x] 테스트 코드 추가 / 수정
- [ ] 테스트 없음 (이유: )

## 🤖 리뷰 포인트
- 확인이 필요한 부분이 있다면 작성

## ⚠️ 참고 사항
- 리뷰어가 알면 좋은 맥락이나 주의사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새 기능**
- 전체/주간/월간 랭킹 조회 기능 추가
- 인증 없이 공개 랭킹 확인 가능
- 개인 랭킹 위치 조회 엔드포인트 추가
- 매일 자동으로 랭킹 스냅샷 계산 및 저장

**구성 변경**
- 랭킹 API 페이지 크기 설정 추가 (최대 100, 기본값 20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->